### PR TITLE
Updated logging driver replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,31 +111,32 @@ sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 ### Commands
 *Synology-Docker* supports the following commands. 
 
-| Command        | Argument  | Description |
-|----------------|-----------|-------------|
-| **`backup`**   |           | Create a backup of Docker binaries (including Docker Compose), `dockerd` configuration, and Synology's `start-stop-status` script |
-| **`download`** | PATH      | Download Docker and Docker Compose binaries to *PATH* |
-| **`install`**  | PATH      | Update Docker and Docker Compose from files on *PATH* |
-| **`restore`**  |           | Restore Docker and Docker Compose from a backup |
-| **`update`**   |           | Update Docker and Docker Compose to a target version (creates a backup first) |
+| Command             | Argument  | Description |
+|---------------------|-----------|-------------|
+| **`backup`**        |           | Create a backup of Docker binaries (including Docker Compose), `dockerd` configuration, and Synology's `start-stop-status` script |
+| **`download`**      | PATH      | Download Docker and Docker Compose binaries to *PATH* |
+| **`install`**       | PATH      | Update Docker and Docker Compose from files on *PATH* |
+| **`restore`**       |           | Restore Docker and Docker Compose from a backup |
+| **`update`**        |           | Update Docker and Docker Compose to a target version (creates a backup first) |
+| **`update-logger`** |           | Update ONLY the logging-driver. This is a good first step to remove the dependency on the synology logger |
 
 Under the hood, the five different commands invoke a specific workflow or sequence of steps. The below table shows the workflows and the order of steps for each of the commands.
-| #  | Workflow step               | backup | download | install | restore | update  |
-|----|-----------------------------|--------|----------|---------|---------|---------|
-| A) | Download Docker binary      |        | Step 1   |         |         | Step 1  |
-| B) | Download Compose binary     |        | Step 2   |         |         | Step 2  |
-| C) | Extract files from backup   |        |          |         | Step 1  |         |
-| D) | Stop Docker daemon          | Step 1 |          | Step 1  | Step 2  | Step 3  |
-| E) | Backup current files        | Step 2 |          | Step 2  |         | Step 4  |
-| F) | Extract downloaded binaries |        |          | Step 3  |         | Step 5  |
-| G) | Restore Docker binaries     |        |          |         | Step 3  |         |
-| H) | Install Docker binaries     |        |          | Step 4  |         | Step 6  |
-| I) | Update log driver           |        |          | Step 5  |         | Step 7  |
-| J) | Restore log driver          |        |          |         | Step 4  |         |
-| K) | Update Docker script        |        |          | Step 5  |         | Step 8  |
-| L) | Restore Docker script       |        |          |         | Step 5  |         |
-| M) | Start Docker daemon         | Step 3 |          | Step 6  | Step 6  | Step 9  |
-| N) | Clean temp folder           |        |          |         |         | Step 10 |
+| #  | Workflow step               | backup | download | install | restore | update  | update-logger |
+|----|-----------------------------|--------|----------|---------|---------|---------|---------------|
+| A) | Download Docker binary      |        | Step 1   |         |         | Step 1  |               |
+| B) | Download Compose binary     |        | Step 2   |         |         | Step 2  |               |
+| C) | Extract files from backup   |        |          |         | Step 1  |         |               |
+| D) | Stop Docker daemon          | Step 1 |          | Step 1  | Step 2  | Step 3  | Step 1        |
+| E) | Backup current files        | Step 2 |          | Step 2  |         | Step 4  | Step 2        |
+| F) | Extract downloaded binaries |        |          | Step 3  |         | Step 5  |               |
+| G) | Restore Docker binaries     |        |          |         | Step 3  |         |               |
+| H) | Install Docker binaries     |        |          | Step 4  |         | Step 6  |               |
+| I) | Update log driver           |        |          | Step 5  |         | Step 7  | Step 3        |
+| J) | Restore log driver          |        |          |         | Step 4  |         |               |
+| K) | Update Docker script        |        |          | Step 5  |         | Step 8  |               |
+| L) | Restore Docker script       |        |          |         | Step 5  |         |               |
+| M) | Start Docker daemon         | Step 3 |          | Step 6  | Step 6  | Step 9  | Step 4        |
+| N) | Clean temp folder           |        |          |         |         | Step 10 |               |
 
 * **A) Download Docker binary** - Downloads an archive containing Docker Engine binaries from `https://download.docker.com/linux/static/stable/x86_64/docker-${VERSION}.tgz`. The binaries are compatible with the Intel x86 (64 bit) architecture. Unless a specific version is specified by the `--docker` flag, *Synology-Docker* pulls the latest stable version available.
 * **B) Download Compose binary** - Downloads the Docker Compose binary from `https://github.com/docker/compose/releases/download/${VERSION}/docker-compose-Linux-x86_64`. Unless a specific version is specified by the `--compose` flag, *Synology-Docker* pulls the latest stable version available.

--- a/README.md
+++ b/README.md
@@ -111,32 +111,32 @@ sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 ### Commands
 *Synology-Docker* supports the following commands. 
 
-| Command               | Argument  | Description |
-|-----------------------|-----------|-------------|
-| **`backup`**          |           | Create a backup of Docker binaries (including Docker Compose), `dockerd` configuration, and Synology's `start-stop-status` script |
-| **`download`**        | PATH      | Download Docker and Docker Compose binaries to *PATH* |
-| **`install`**         | PATH      | Update Docker and Docker Compose from files on *PATH* |
-| **`restore`**         |           | Restore Docker and Docker Compose from a backup |
-| **`update`**          |           | Update Docker and Docker Compose to a target version (creates a backup first) |
-| **`update-logger`**   |           | Update ONLY the logging-driver. This is a good first step to remove the dependency on the synology logger |
+| Command        | Argument  | Description |
+|----------------|-----------|-------------|
+| **`backup`**   |           | Create a backup of Docker binaries (including Docker Compose), `dockerd` configuration, and Synology's `start-stop-status` script |
+| **`download`** | PATH      | Download Docker and Docker Compose binaries to *PATH* |
+| **`install`**  | PATH      | Update Docker and Docker Compose from files on *PATH* |
+| **`restore`**  |           | Restore Docker and Docker Compose from a backup |
+| **`update`**   |           | Update Docker and Docker Compose to a target version (creates a backup first) |
+| **`logger`**   |           | Update ONLY the logging-driver. This is a good first step to remove the dependency on the synology logger |
 
 Under the hood, the five different commands invoke a specific workflow or sequence of steps. The below table shows the workflows and the order of steps for each of the commands.
-| #  | Workflow step               | backup | download | install | restore | update  | update-logger |
-|----|-----------------------------|--------|----------|---------|---------|---------|---------------|
-| A) | Download Docker binary      |        | Step 1   |         |         | Step 1  |               |
-| B) | Download Compose binary     |        | Step 2   |         |         | Step 2  |               |
-| C) | Extract files from backup   |        |          |         | Step 1  |         |               |
-| D) | Stop Docker daemon          | Step 1 |          | Step 1  | Step 2  | Step 3  | Step 1        |
-| E) | Backup current files        | Step 2 |          | Step 2  |         | Step 4  | Step 2        |
-| F) | Extract downloaded binaries |        |          | Step 3  |         | Step 5  |               |
-| G) | Restore Docker binaries     |        |          |         | Step 3  |         |               |
-| H) | Install Docker binaries     |        |          | Step 4  |         | Step 6  |               |
-| I) | Update log driver           |        |          | Step 5  |         | Step 7  | Step 3        |
-| J) | Restore log driver          |        |          |         | Step 4  |         |               |
-| K) | Update Docker script        |        |          | Step 5  |         | Step 8  |               |
-| L) | Restore Docker script       |        |          |         | Step 5  |         |               |
-| M) | Start Docker daemon         | Step 3 |          | Step 6  | Step 6  | Step 9  | Step 4        |
-| N) | Clean temp folder           |        |          |         |         | Step 10 |               |
+| #  | Workflow step               | backup | download | install | restore | update  | logger |
+|----|-----------------------------|--------|----------|---------|---------|---------|--------|
+| A) | Download Docker binary      |        | Step 1   |         |         | Step 1  |        |
+| B) | Download Compose binary     |        | Step 2   |         |         | Step 2  |        |
+| C) | Extract files from backup   |        |          |         | Step 1  |         |        |
+| D) | Stop Docker daemon          | Step 1 |          | Step 1  | Step 2  | Step 3  | Step 1 |
+| E) | Backup current files        | Step 2 |          | Step 2  |         | Step 4  | Step 2 |
+| F) | Extract downloaded binaries |        |          | Step 3  |         | Step 5  |        |
+| G) | Restore Docker binaries     |        |          |         | Step 3  |         |        |
+| H) | Install Docker binaries     |        |          | Step 4  |         | Step 6  |        |
+| I) | Update log driver           |        |          | Step 5  |         | Step 7  | Step 3 |
+| J) | Restore log driver          |        |          |         | Step 4  |         |        |
+| K) | Update Docker script        |        |          | Step 5  |         | Step 8  |        |
+| L) | Restore Docker script       |        |          |         | Step 5  |         |        |
+| M) | Start Docker daemon         | Step 3 |          | Step 6  | Step 6  | Step 9  | Step 4 |
+| N) | Clean temp folder           |        |          |         |         | Step 10 |        |
 
 * **A) Download Docker binary** - Downloads an archive containing Docker Engine binaries from `https://download.docker.com/linux/static/stable/x86_64/docker-${VERSION}.tgz`. The binaries are compatible with the Intel x86 (64 bit) architecture. Unless a specific version is specified by the `--docker` flag, *Synology-Docker* pulls the latest stable version available.
 * **B) Download Compose binary** - Downloads the Docker Compose binary from `https://github.com/docker/compose/releases/download/${VERSION}/docker-compose-Linux-x86_64`. Unless a specific version is specified by the `--compose` flag, *Synology-Docker* pulls the latest stable version available.

--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 ### Commands
 *Synology-Docker* supports the following commands. 
 
-| Command             | Argument  | Description |
-|---------------------|-----------|-------------|
-| **`backup`**        |           | Create a backup of Docker binaries (including Docker Compose), `dockerd` configuration, and Synology's `start-stop-status` script |
-| **`download`**      | PATH      | Download Docker and Docker Compose binaries to *PATH* |
-| **`install`**       | PATH      | Update Docker and Docker Compose from files on *PATH* |
-| **`restore`**       |           | Restore Docker and Docker Compose from a backup |
-| **`update`**        |           | Update Docker and Docker Compose to a target version (creates a backup first) |
-| **`update-logger`** |           | Update ONLY the logging-driver. This is a good first step to remove the dependency on the synology logger |
+| Command               | Argument  | Description |
+|-----------------------|-----------|-------------|
+| **`backup`**          |           | Create a backup of Docker binaries (including Docker Compose), `dockerd` configuration, and Synology's `start-stop-status` script |
+| **`download`**        | PATH      | Download Docker and Docker Compose binaries to *PATH* |
+| **`install`**         | PATH      | Update Docker and Docker Compose from files on *PATH* |
+| **`restore`**         |           | Restore Docker and Docker Compose from a backup |
+| **`update`**          |           | Update Docker and Docker Compose to a target version (creates a backup first) |
+| **`update-logger`**   |           | Update ONLY the logging-driver. This is a good first step to remove the dependency on the synology logger |
 
 Under the hood, the five different commands invoke a specific workflow or sequence of steps. The below table shows the workflows and the order of steps for each of the commands.
 | #  | Workflow step               | backup | download | install | restore | update  | update-logger |

--- a/syno_docker_switch_logger.sh
+++ b/syno_docker_switch_logger.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+
+terminate() {
+    printf "${RED}${BOLD}%s${NC}\n" "ERROR: $1"
+	echo
+    exit 1
+}
+
+usage() {
+    echo "Usage: (as root) $0 [PATH_TO_DOCKERD.JSON]"
+    echo
+    echo "This script will modify the logger in the dockerd.json file to 'local'"
+    echo
+}
+
+readonly RED='\e[31m' # Red color
+readonly NC='\e[m' # No color / reset
+readonly BOLD='\e[1m' # Bold font
+DOCKERD_FILE=$1
+
+# Test if script has root privileges, exit otherwise
+id=$(id -u)
+if [ "${id}" -ne 0 ]; then
+	usage
+	terminate "You need to be root to run this script"
+fi
+
+# Check if the dockerd.json file path is provided as an argument
+if [ -z "$1" ]; then
+	usage
+	terminate "no path to dockerd.json provided"
+fi
+
+# Check if dockerd.json file exists
+if [ ! -f "${DOCKERD_FILE}" ]; then
+	usage
+	terminate "no dockerd.json found at provided location"
+fi
+
+# Output the original JSON file
+echo "Original dockerd.json file:"
+echo "----------------------------"
+echo
+cat "${DOCKERD_FILE}" | jq
+echo
+
+# Use jq to safely update the log-driver and merge new log-opts
+jq '
+  .["group"] = "administrators" |
+  .["log-driver"] = "local" |
+  .["log-opts"] = {
+    "max-file": "5",
+    "max-size": "20m"
+  }
+' "$DOCKERD_FILE" > "$DOCKERD_FILE.tmp" && mv "$DOCKERD_FILE.tmp" "$DOCKERD_FILE"
+
+# Output the new JSON file
+echo "Updated dockerd.json file:"
+echo "----------------------------"
+echo
+cat "${DOCKERD_FILE}" | jq
+echo
+
+exit 0

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -53,16 +53,6 @@ readonly SYNO_DOCKER_SCRIPT_PATH="${SYNO_DOCKER_DIR}/scripts"
 readonly SYNO_DOCKER_SCRIPT="${SYNO_DOCKER_SCRIPT_PATH}/start-stop-status"
 readonly SYNO_DOCKER_JSON_PATH="${SYNO_DOCKER_DIR}/etc"
 readonly SYNO_DOCKER_JSON="${SYNO_DOCKER_JSON_PATH}/dockerd.json"
-readonly SYNO_DOCKER_JSON_CONFIG="{
-    \"data-root\" : \"$SYNO_DOCKER_DIR/target/docker\",
-    \"log-driver\" : \"local\",
-    \"log-opts\" : {
-		\"max-size\" : \"10m\",
-		\"max-file\" : \"3\"
-	},
-    \"registry-mirrors\" : [],
-    \"group\": \"administrators\"
-}"
 readonly SYNO_DOCKER_SCRIPT_FORWARDING='# ensure IP forwarding\n\t\tsudo iptables -P FORWARD ACCEPT\n'
 readonly SYNO_SERVICE_STOP_TIMEOUT='5m'
 RUNNING_CONTAINERS=$(docker ps -q 2>/dev/null | wc -l 2>/dev/null || echo 0)
@@ -127,6 +117,7 @@ usage() {
     echo "  install [PATH]         Update Docker and Docker Compose from files on PATH"
     echo "  restore                Restore Docker and Docker Compose from backup"
     echo "  update                 Update Docker and Docker Compose to target version (creates backup first)"
+    echo "  update-logger          Update ONLY the logging driver to the local logger (a proactive preparation step)"
     echo "  validate               Validates versions available for update"
     echo
 }
@@ -864,11 +855,7 @@ execute_restore_bin() {
 execute_update_log() {
     print_status "Configuring log driver"
     if [ "${stage}" = 'false' ] && [ "${skip_driver_update}" = 'false' ] ; then
-        log_driver=$(grep "json-file" "${SYNO_DOCKER_JSON}")
-        if [ ! -f "${SYNO_DOCKER_JSON}" ] || [ -z "${log_driver}" ] ; then
-            mkdir -p "${SYNO_DOCKER_JSON_PATH}"
-            echo "${SYNO_DOCKER_JSON_CONFIG}" > "${SYNO_DOCKER_JSON}"
-        fi
+		./syno_docker_switch_logger.sh "${SYNO_DOCKER_JSON}"
     else
         echo "Skipping configuration in STAGE mode or TARGET mode"
     fi
@@ -1055,7 +1042,7 @@ main() {
                 target="$1"
                 validate_target "Invalid target"
                 ;;
-            backup | restore | update | validate )
+            backup | restore | update | update-logger | validate )
                 command="$1"
                 ;;
             download | install )
@@ -1114,6 +1101,15 @@ main() {
             execute_restore_bin
             execute_restore_log
             execute_restore_script
+            execute_start_syno
+            ;;
+        update-logger )
+            total_steps=4
+            detect_current_versions
+            execute_prepare
+            execute_stop_syno
+            execute_backup
+            execute_update_log
             execute_start_syno
             ;;
         update )

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -117,7 +117,7 @@ usage() {
     echo "  install [PATH]         Update Docker and Docker Compose from files on PATH"
     echo "  restore                Restore Docker and Docker Compose from backup"
     echo "  update                 Update Docker and Docker Compose to target version (creates backup first)"
-    echo "  update-logger          Update ONLY the logging driver to the local logger (a proactive preparation step)"
+    echo "  logger          Update ONLY the logging driver to the local logger (a proactive preparation step)"
     echo "  validate               Validates versions available for update"
     echo
 }
@@ -1042,7 +1042,7 @@ main() {
                 target="$1"
                 validate_target "Invalid target"
                 ;;
-            backup | restore | update | update-logger | validate )
+            backup | restore | update | logger | validate )
                 command="$1"
                 ;;
             download | install )
@@ -1103,7 +1103,7 @@ main() {
             execute_restore_script
             execute_start_syno
             ;;
-        update-logger )
+        logger )
             total_steps=4
             detect_current_versions
             execute_prepare

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -6,7 +6,7 @@
 # Orig. Author  : Mark Dumay
 # Maintainer    : Jason Hobbs (telnetdoogie)
 # Date          : October 12th, 2024
-# Version       : 2.0.0
+# Version       : 2.1.0
 # Usage         : sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 # Repository    : https://github.com/telnetdoogie/synology-docker.git
 # License       : MIT - https://github.com/telnetdoogie/synology-docker/blob/master/LICENSE

--- a/test_file/dockerd.json
+++ b/test_file/dockerd.json
@@ -1,0 +1,23 @@
+{
+  "data-root": "/var/packages/ContainerManager/var/docker",
+  "group": "administrators",
+  "log-driver": "db",
+  "log-opts": {
+	"some-obsolete-setting": "1337"
+  },
+  "registry-mirrors": [],
+  "storage-driver": "btrfs",
+  "default-address-pools": [
+    {
+      "base": "172.16.0.0/12",
+      "size": 24
+    }
+  ],
+  "runtimes": {
+	"nvidia": {
+		"path": "/usr/bin/nvidia-container-runtime",
+		"runtimeArgs": []
+	}
+  }
+}
+


### PR DESCRIPTION
This version:
 - externalizes the code for updating the logging driver
 - MODIFIES versus replaces the `dockerd.json` file with the new logger
 - adds a new command which ONLY updates the logger and does not update docker versions
 
