### PR TITLE
remove BC dependency and update readme for HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The project uses [Docker][docker_url], a lightweight virtualization application.
 Deployment of *Synology-Docker* is a matter of cloning the GitHub repository. Login to your NAS terminal via SSH first. Assuming you are in the working folder of your choice, clone the repository files. Git automatically creates a new folder `synology-docker` and copies the files to this directory. Then change your current folder to simplify the execution of the shell script.
 
 ```console
-git clone git@github.com:telnetdoogie/synology-docker.git
+git clone https://github.com/telnetdoogie/synology-docker.git
 cd synology-docker
 ```
 

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -6,7 +6,7 @@
 # Orig. Author  : Mark Dumay
 # Maintainer    : Jason Hobbs (telnetdoogie)
 # Date          : October 12th, 2024
-# Version       : 2.1.0
+# Version       : 2.1.1
 # Usage         : sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 # Repository    : https://github.com/telnetdoogie/synology-docker.git
 # License       : MIT - https://github.com/telnetdoogie/synology-docker/blob/master/LICENSE
@@ -57,11 +57,10 @@ readonly SYNO_DOCKER_SCRIPT_FORWARDING='# ensure IP forwarding\n\t\tsudo iptable
 readonly SYNO_SERVICE_STOP_TIMEOUT='5m'
 RUNNING_CONTAINERS=$(docker ps -q 2>/dev/null | wc -l 2>/dev/null || echo 0)
 if [ "$RUNNING_CONTAINERS" -gt 5 ]; then
-    readonly SYNO_SERVICE_START_TIMEOUT=$(echo "$RUNNING_CONTAINERS * 1.5" | bc)m
+    readonly SYNO_SERVICE_START_TIMEOUT=$(( (RUNNING_CONTAINERS * 3) / 2 ))m
 else
 	readonly SYNO_SERVICE_START_TIMEOUT='5m'
 fi
-
 
 #======================================================================================================================
 # Variables


### PR DESCRIPTION
This change removes the dependency on `bc` since most users won't have that installed
It also updates the README to refer to HTTPS for cloning since many users may not use git/ssh and keys.