### PR TITLE
v2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Once you've successfully updated your docker version with this script, subsequen
 ```console
 cd synology-docker
 git pull
-./syno_docker_update.sh update
+sudo ./syno_docker_update.sh update
 ```
 
 The biggest 'hump' is the initial shift to the `local` loggers. After the first successful update, each update beyond that is very simple.

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -2,16 +2,9 @@
 
 #======================================================================================================================
 # Title         : syno_docker_update.sh
-# Description   : An Unofficial Script to Update or Restore Docker Engine and Docker Compose on Synology
-# Orig. Author  : Mark Dumay
-# Maintainer    : Jason Hobbs (telnetdoogie)
 # Date          : October 12th, 2024
-# Version       : 2.3.1
 # Usage         : sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 # Repository    : https://github.com/telnetdoogie/synology-docker.git
-# License       : MIT - https://github.com/telnetdoogie/synology-docker/blob/master/LICENSE
-# Credits       : Inspired by https://gist.github.com/Mikado8231/bf207a019373f9e539af4d511ae15e0d
-# Comments      : Use this script at your own risk. Refer to the license for the warranty disclaimer.
 #======================================================================================================================
 
 #======================================================================================================================

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -6,7 +6,7 @@
 # Orig. Author  : Mark Dumay
 # Maintainer    : Jason Hobbs (telnetdoogie)
 # Date          : October 12th, 2024
-# Version       : 2.3.0
+# Version       : 2.3.1
 # Usage         : sudo ./syno_docker_update.sh [OPTIONS] COMMAND
 # Repository    : https://github.com/telnetdoogie/synology-docker.git
 # License       : MIT - https://github.com/telnetdoogie/synology-docker/blob/master/LICENSE
@@ -79,7 +79,7 @@ RUNNING_CONTAINERS=$(docker ps -q 2>/dev/null | wc -l 2>/dev/null || echo 0)
 if [ "$RUNNING_CONTAINERS" -gt 5 ]; then
     readonly SYNO_SERVICE_START_TIMEOUT=$(( (RUNNING_CONTAINERS * 3) / 2 ))m
 else
-	readonly SYNO_SERVICE_START_TIMEOUT='5m'
+    readonly SYNO_SERVICE_START_TIMEOUT=10m
 fi
 
 #======================================================================================================================


### PR DESCRIPTION
docs: missing sudo in documentation
fix: fixes too-short default timeout on <5 running containers from 5m to 10m (#10)