### PR TITLE
feat: skip logger step is logger already set to local

### DIFF
--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -515,6 +515,12 @@ define_update() {
             skip_compose_update='true'
             total_steps=$((total_steps-1))
         fi
+        
+        log_driver=$(jq -r '.["log-driver"] // empty' "${SYNO_DOCKER_JSON}")
+        if [ "$log_driver" = "local" ]; then
+          skip_driver_update='true'
+          total_steps=$((total_steps-1))
+        fi
     fi
 }
 


### PR DESCRIPTION
Script should skip the logger update if local logger is already set in JSON file.