### PR TITLE
Fix synopkg/synoservicectl PATH resolution under sudo on DSM

### DIFF
--- a/syno_docker_switch_logger.sh
+++ b/syno_docker_switch_logger.sh
@@ -42,7 +42,7 @@ fi
 echo "Original dockerd.json file:"
 echo "----------------------------"
 echo
-jq < ${DOCKERD_FILE}
+jq . "${DOCKERD_FILE}"
 echo
 
 # Use jq to safely update the log-driver and merge new log-opts
@@ -71,7 +71,7 @@ jq '
 echo "Updated dockerd.json file:"
 echo "----------------------------"
 echo
-jq < ${DOCKERD_FILE}
+jq . "${DOCKERD_FILE}"
 echo
 
 exit 0

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -16,7 +16,7 @@
 #   Writes error message to stderr, non-zero exit code.
 #======================================================================================================================
 terminate() {
-  printf "${RED}${BOLD}%s${NC}\n" "ERROR: $1"
+  printf "${RED}${BOLD}%s${NC}\n" "ERROR: $1" >&2
   exit 1
 }
 
@@ -660,6 +660,32 @@ resolve_syno_bin() {
 }
 
 #======================================================================================================================
+# Fails fast if the Synology package-control tool needed to stop/start the Docker package ('synopkg' on DSM 7,
+# 'synoservicectl' on DSM 6) is not resolvable - rather than only discovering this midway through a run, when
+# execute_stop_syno/execute_start_syno are reached.
+#======================================================================================================================
+# Globals:
+#   - dsm_major_version
+#   - stage
+# Outputs:
+#   Terminates with a non-zero exit code if the required tool cannot be resolved, unless 'stage' is true.
+#======================================================================================================================
+validate_syno_tools() {
+  if [ "${stage}" = 'true' ] ; then
+    return
+  fi
+
+  case "${dsm_major_version}" in
+    "6")
+      resolve_syno_bin "synoservicectl" "${SYNOSERVICECTL_BIN}" >/dev/null
+      ;;
+    "7")
+      resolve_syno_bin "synopkg" "${SYNOPKG_BIN}" >/dev/null
+      ;;
+  esac
+}
+
+#======================================================================================================================
 # Workflow Functions
 #======================================================================================================================
 
@@ -1203,6 +1229,7 @@ main() {
     install )
       total_steps=8
       detect_current_versions
+      validate_syno_tools
       execute_prepare
       define_target_download
       confirm_operation
@@ -1218,6 +1245,7 @@ main() {
     restore )
       total_steps=6
       detect_current_versions
+      validate_syno_tools
       execute_prepare
       define_restore
       confirm_operation
@@ -1231,6 +1259,7 @@ main() {
     logger )
       total_steps=4
       detect_current_versions
+      validate_syno_tools
       execute_prepare
       execute_stop_syno
       execute_backup
@@ -1240,6 +1269,7 @@ main() {
     update )
       total_steps=12
       detect_current_versions
+      validate_syno_tools
       execute_prepare
       define_target_version
       define_update

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -72,6 +72,8 @@ readonly SYNO_DOCKER_JSON_PATH="${SYNO_DOCKER_DIR}/etc"
 readonly SYNO_DOCKER_JSON="${SYNO_DOCKER_JSON_PATH}/dockerd.json"
 readonly SYNO_DOCKER_SCRIPT_FORWARDING="            # Added by docker update\n          iptables -P FORWARD ACCEPT\n          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
 readonly SYNO_SERVICE_STOP_TIMEOUT='10m'
+readonly SYNOPKG_BIN='/usr/syno/bin/synopkg'
+readonly SYNOSERVICECTL_BIN='/usr/syno/sbin/synoservicectl'
 RUNNING_CONTAINERS=$(docker ps -q 2>/dev/null | awk 'NF' | wc -l)
 if [ $? -ne 0 ]; then
   RUNNING_CONTAINERS=0
@@ -633,6 +635,31 @@ confirm_operation() {
 }
 
 #======================================================================================================================
+# Resolves the absolute path to a Synology system control binary ('synopkg' or 'synoservicectl').
+#======================================================================================================================
+# Arguments:
+#   $1 - Binary name (e.g. 'synopkg' or 'synoservicectl').
+#   $2 - Well-known absolute path for this binary on DSM (e.g. '/usr/syno/bin/synopkg').
+# Outputs:
+#   Writes the resolved absolute path to stdout. Terminates with a non-zero exit code if the
+#   binary cannot be found at the well-known path or on PATH - this commonly happens when the
+#   script is run via 'sudo', whose default PATH does not include '/usr/syno/bin' or
+#   '/usr/syno/sbin'.
+#======================================================================================================================
+resolve_syno_bin() {
+  local bin_name="$1"
+  local well_known_path="$2"
+
+  if [ -x "${well_known_path}" ]; then
+    echo "${well_known_path}"
+  elif command -v "${bin_name}" >/dev/null 2>&1; then
+    command -v "${bin_name}"
+  else
+    terminate "Could not find '${bin_name}' (checked '${well_known_path}' and PATH). Cannot control the ${SYNO_DOCKER_SERV_NAME} package. If running via 'sudo', ensure PATH includes '/usr/syno/bin' and '/usr/syno/sbin', e.g.: sudo env PATH=/usr/syno/bin:/usr/syno/sbin:\$PATH $0 ..."
+  fi
+}
+
+#======================================================================================================================
 # Workflow Functions
 #======================================================================================================================
 
@@ -663,20 +690,22 @@ execute_stop_syno() {
   if [ "${stage}" = 'false' ] ; then
     case "${dsm_major_version}" in
       "6")
-        syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME}" | grep running -o)
+        synoservicectl_bin=$(resolve_syno_bin "synoservicectl" "${SYNOSERVICECTL_BIN}")
+        syno_status=$("${synoservicectl_bin}" --status "${SYNO_DOCKER_SERV_NAME}" | grep running -o)
         if [ "${syno_status}" = 'running' ] ; then
-          timeout --foreground "${SYNO_SERVICE_STOP_TIMEOUT}" synoservicectl --stop "${SYNO_DOCKER_SERV_NAME}"
-          syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME}" | grep stop -o)
+          timeout --foreground "${SYNO_SERVICE_STOP_TIMEOUT}" "${synoservicectl_bin}" --stop "${SYNO_DOCKER_SERV_NAME}"
+          syno_status=$("${synoservicectl_bin}" --status "${SYNO_DOCKER_SERV_NAME}" | grep stop -o)
           if [ "${syno_status}" != 'stop' ] ; then
             terminate "Could not stop Docker daemon"
           fi
         fi
         ;;
       "7")
-        syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME}" | grep started -o)
+        synopkg_bin=$(resolve_syno_bin "synopkg" "${SYNOPKG_BIN}")
+        syno_status=$("${synopkg_bin}" status "${SYNO_DOCKER_SERV_NAME}" | grep started -o)
         if [ "${syno_status}" = 'started' ] ; then
-          timeout --foreground "${SYNO_SERVICE_STOP_TIMEOUT}" synopkg stop "${SYNO_DOCKER_SERV_NAME}"
-          syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME}" | grep stopped -o)
+          timeout --foreground "${SYNO_SERVICE_STOP_TIMEOUT}" "${synopkg_bin}" stop "${SYNO_DOCKER_SERV_NAME}"
+          syno_status=$("${synopkg_bin}" status "${SYNO_DOCKER_SERV_NAME}" | grep stopped -o)
           if [ "${syno_status}" != 'stopped' ] ; then
             terminate "Could not stop Docker daemon"
           fi
@@ -1003,9 +1032,10 @@ execute_start_syno() {
   if [ "${stage}" = 'false' ] ; then
     case "${dsm_major_version}" in
       "6")
-        timeout --foreground "${SYNO_SERVICE_START_TIMEOUT}" synoservicectl --start "${SYNO_DOCKER_SERV_NAME}"
+        synoservicectl_bin=$(resolve_syno_bin "synoservicectl" "${SYNOSERVICECTL_BIN}")
+        timeout --foreground "${SYNO_SERVICE_START_TIMEOUT}" "${synoservicectl_bin}" --start "${SYNO_DOCKER_SERV_NAME}"
 
-        syno_status=$(synoservicectl --status "${SYNO_DOCKER_SERV_NAME}" | grep running -o)
+        syno_status=$("${synoservicectl_bin}" --status "${SYNO_DOCKER_SERV_NAME}" | grep running -o)
         if [ "${syno_status}" != 'running' ] ; then
           if [ "${force}" != 'true' ] ; then
             terminate "Could not bring Docker Engine back online"
@@ -1015,9 +1045,10 @@ execute_start_syno() {
         fi
         ;;
       "7")
-        timeout --foreground "${SYNO_SERVICE_START_TIMEOUT}" synopkg start "${SYNO_DOCKER_SERV_NAME}"
+        synopkg_bin=$(resolve_syno_bin "synopkg" "${SYNOPKG_BIN}")
+        timeout --foreground "${SYNO_SERVICE_START_TIMEOUT}" "${synopkg_bin}" start "${SYNO_DOCKER_SERV_NAME}"
 
-        syno_status=$(synopkg status "${SYNO_DOCKER_SERV_NAME}" | grep started -o)
+        syno_status=$("${synopkg_bin}" status "${SYNO_DOCKER_SERV_NAME}" | grep started -o)
         if [ "${syno_status}" != 'started' ] ; then
           if [ "${force}" != 'true' ] ; then
             terminate "Could not bring Docker Engine back online"


### PR DESCRIPTION
## Problem

When `syno_docker_update.sh` is run via `sudo` over SSH on DSM 7, `sudo`'s default `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) does not include `/usr/syno/bin` (where `synopkg` lives) or `/usr/syno/sbin` (where `synoservicectl` lives on DSM 6). The bare `synopkg`/`synoservicectl` calls in `execute_stop_syno()` / `execute_start_syno()` then fail silently:

1. **"Stopping Docker service" silently no-ops** — the daemon is never stopped, no error shown.
2. **"Installing binaries" partially fails** with `cp: cannot create regular file '...': Text file busy` for `dockerd`, `containerd`, `containerd-shim-runc-v2`, `docker-proxy` — still in use by the never-stopped daemon.
3. **"Starting Docker service" fails** with:
   ```
   timeout: failed to run command 'synopkg': No such file or directory
   ./syno_docker_update.sh: line 1020: synopkg: command not found
   ERROR: Could not bring Docker Engine back online
   ```
   (non-fatal only with `--force`).

Net result: a **mixed-version install** — `docker` CLI and most helper binaries get updated, but the running daemon binaries (`dockerd`, `containerd`, etc.) stay on the old version, so `docker version` reports mismatched Client/Server versions. Each of the 12 steps still reports as completed, so this is easy to miss in a long log.

**Workaround** (confirmed working): explicitly set `PATH` to include `/usr/syno/bin` (and `/usr/syno/sbin`, `/usr/local/bin`):
```sh
sudo env PATH=/usr/local/bin:/usr/syno/bin:/usr/syno/sbin:/usr/bin:/bin:/usr/sbin:/sbin \
  ./syno_docker_update.sh -d 28.5.2 -t engine -f update
```

## Fix

Adds `resolve_syno_bin()`:
- Tries the well-known absolute path first (`/usr/syno/bin/synopkg` for DSM 7, `/usr/syno/sbin/synoservicectl` for DSM 6) — these paths are PATH-independent and stable across DSM installs.
- Falls back to `command -v` (preserves prior behavior if the well-known path is ever wrong).
- `terminate`s with a clear error (including a `sudo env PATH=...` hint) if neither resolves, instead of silently no-op'ing or surfacing a buried "command not found" several steps later.

`execute_stop_syno()` and `execute_start_syno()` now resolve the binary once per DSM-version branch and use it for all `status`/`stop`/`start` invocations.

## Cosmetic fix

`syno_docker_switch_logger.sh` used `jq < "$DOCKERD_FILE"` (no filter) for the before/after dumps, which prints jq's usage/help text instead of pretty-printing the file. Changed to `jq . "$DOCKERD_FILE"`.

## Testing

- `bash -n` syntax check on both modified scripts.
- Unit tests on `resolve_syno_bin()` (extracted from the modified script) covering: well-known path present, well-known path absent + found on `PATH`, neither found (terminates with clear error), and well-known path present despite a stripped `PATH`.
- **Live verification on a DSM 7 unit** (read-only — no `synopkg stop/start` invoked): confirmed `/usr/syno/bin/synopkg` exists and is executable, and reproduced the original bug — under the exact sudo `PATH` from the report (`/usr/bin:/bin:/usr/sbin:/sbin`), `command -v synopkg` returns not-found, while `resolve_syno_bin "synopkg" "/usr/syno/bin/synopkg"` correctly resolves regardless of `PATH`.

**Note:** I've only been able to test this on **DSM 7** (ContainerManager / `synopkg`). The DSM 6 path (`/usr/syno/sbin/synoservicectl`) is based on general knowledge of the DSM 6 layout but is unverified on real hardware. If that hardcoded path is wrong on some DSM 6 systems, `resolve_syno_bin()` falls back to `command -v synoservicectl`, which matches the *prior* (PATH-dependent) behavior exactly — so DSM 6 should not regress even in that case. Happy to adjust if a DSM 6 user can confirm the correct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)