### PR TITLE
[FR] Fix start-stop-status ordering for FORWARD rules; add AppArmor profile install to unbreak Docker 29.x

### DIFF
--- a/fix_ipforward.sh
+++ b/fix_ipforward.sh
@@ -8,33 +8,32 @@ if [ "${id}" -ne 0 ]; then
 fi
 
 # Define the lines to insert
-INSERT="  # Added by docker update\n  iptables -P FORWARD ACCEPT\n  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
+INSERT="            # Added by docker update\n          iptables -P FORWARD ACCEPT\n          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
 
 # File to edit
 file="/var/packages/ContainerManager/scripts/start-stop-status"
 
-# Search and check conditions
-if ! grep -q 'iptables -P FORWARD ACCEPT' "${file}"; then
-  match="^[[:space:]]*iptablestool --insmod"
-  # Use sed to append the lines after the match
-  sed -i "/${match}/a\\${INSERT}" "${file}"
-  echo "Added missing IP forwarding configuration to ${file}"
-  echo
-  echo "To avoid a restart of docker, adding the rule now. This should automatically apply"
-  echo "  with the next docker restart"
-  iptables -P FORWARD ACCEPT
-  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
-else
-  echo "IP forwarding is already enabled in ${file}."
-fi
+# Remove any previously-inserted forwarding block, wherever it landed. Earlier versions inserted it
+# before 'start_docker_daemon', where the DOCKER-FORWARD chain does not yet exist. The insmod block
+# sharing the same comment is left untouched.
+sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
+sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
+sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
 
-# Ensure DOCKER-FORWARD jump rule is present (Docker v25+ compatibility)
-if ! grep -q 'DOCKER-FORWARD' "${file}"; then
-  match="^[[:space:]]*iptables -P FORWARD ACCEPT"
-  sed -i "/${match}/a\\  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD" "${file}"
-  echo "Added DOCKER-FORWARD jump rule to ${file}"
-  echo
-  echo "To avoid a restart of docker, adding the rule now. This should automatically apply"
-  echo "  with the next docker restart"
-  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
+# Insert only after the daemon is confirmed up. dockerd creates the DOCKER-FORWARD chain, so the
+# jump rule cannot be added any earlier.
+match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+if grep -qE "${match}" "${file}"; then
+  sed -i "/${match}/i\\${INSERT}" "${file}"
+  echo "Added IP forwarding configuration to ${file} (post daemon start)"
+else
+  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+  echo "         IP forwarding configuration was NOT added -- check the file manually."
+  exit 1
 fi
+echo
+echo "To avoid a restart of docker, adding the rules now. This should automatically apply"
+echo " with the next docker restart"
+iptables -P FORWARD ACCEPT
+iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD

--- a/fix_ipforward.sh
+++ b/fix_ipforward.sh
@@ -13,6 +13,15 @@ INSERT="            # Added by docker update\n          iptables -P FORWARD ACCE
 # File to edit
 file="/var/packages/ContainerManager/scripts/start-stop-status"
 
+# Verify the insertion anchor exists before touching the file, so a missing anchor leaves
+# the file unmodified.
+match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+if ! grep -qE "${match}" "${file}"; then
+  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+  echo "         File left unmodified -- check the file manually."
+  exit 1
+fi
+
 # Remove any previously-inserted forwarding block, wherever it landed. Earlier versions inserted it
 # before 'start_docker_daemon', where the DOCKER-FORWARD chain does not yet exist. The insmod block
 # sharing the same comment is left untouched.
@@ -23,15 +32,8 @@ sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
 
 # Insert only after the daemon is confirmed up. dockerd creates the DOCKER-FORWARD chain, so the
 # jump rule cannot be added any earlier.
-match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
-if grep -qE "${match}" "${file}"; then
-  sed -i "/${match}/i\\${INSERT}" "${file}"
-  echo "Added IP forwarding configuration to ${file} (post daemon start)"
-else
-  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
-  echo "         IP forwarding configuration was NOT added -- check the file manually."
-  exit 1
-fi
+sed -i "/${match}/i\\${INSERT}" "${file}"
+echo "Added IP forwarding configuration to ${file} (post daemon start)"
 echo
 echo "To avoid a restart of docker, adding the rules now. This should automatically apply"
 echo " with the next docker restart"

--- a/install_apparmor_profile.sh
+++ b/install_apparmor_profile.sh
@@ -63,8 +63,8 @@ PROFILE_EOF
 echo " - profile written to ${PROFILE}"
 
 # Load it now (replace if already loaded)
-if ! apparmor_parser -Kr "${PROFILE}"; then
-  echo "ERROR: apparmor_parser could not load ${PROFILE}"
+if ! /sbin/apparmor_parser -Kr "${PROFILE}"; then
+  echo "ERROR: /sbin/apparmor_parser could not load ${PROFILE}"
   exit 1
 fi
 if ! grep -q 'docker-default' /sys/kernel/security/apparmor/profiles; then
@@ -76,7 +76,7 @@ echo " - docker-default profile loaded ? 🟢"
 # Load it at every ContainerManager start, before dockerd. The profile is
 # consumed by dockerd, so unlike the FORWARD rules this must run pre-daemon.
 if ! grep -q 'docker-default.profile' "${SSS}"; then
-  INSERT="            # Added by docker update\n            [ -f ${PROFILE} ] && apparmor_parser -Kr ${PROFILE}"
+  INSERT="            # Added by docker update\n            [ -f \"${PROFILE}\" ] && /sbin/apparmor_parser -Kr \"${PROFILE}\""
   match="^[[:space:]]*# start docker[[:space:]]*$"
   sed -i "/${match}/i\\${INSERT}" "${SSS}"
   if grep -q 'docker-default.profile' "${SSS}"; then

--- a/install_apparmor_profile.sh
+++ b/install_apparmor_profile.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Installs a docker-default AppArmor profile and configures ContainerManager to
+# load it before dockerd starts.
+#
+# Docker >= 29.4.3 pipes its generated docker-default profile to apparmor_parser
+# via stdin, which segfaults DSM's apparmor_parser (2.9, 2014-era). Containers
+# then fail to start with:
+#   "AppArmor enabled on system but the docker-default profile could not be
+#    loaded: ... signal: segmentation fault"
+# dockerd skips generating/loading the profile when one named docker-default is
+# already loaded, so pre-loading a compatible profile avoids the crash entirely.
+# See https://github.com/moby/moby/issues/52785
+
+if [ -d "/var/packages/ContainerManager" ]; then
+  PKG_DIR='/var/packages/ContainerManager'
+elif [ -d "/var/packages/Docker" ]; then
+  PKG_DIR='/var/packages/Docker'
+else
+  echo "Docker (or ContainerManager) folder was not found."
+  exit 1
+fi
+
+PROFILE="${PKG_DIR}/etc/docker-default.profile"
+SSS="${PKG_DIR}/scripts/start-stop-status"
+
+# No AppArmor on this system - nothing to do
+if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" != "Y" ]; then
+  echo " - AppArmor not enabled on this system, skipping profile install."
+  exit 0
+fi
+
+# Profile derived from moby's contrib/apparmor template, in syntax accepted by
+# DSM's apparmor_parser 2.9 (no includes, no @{PROC} tunables, no ptrace/signal
+# rules - not mediated on these kernels).
+cat > "${PROFILE}" << 'PROFILE_EOF'
+profile docker-default flags=(attach_disconnected,mediate_deleted) {
+  network,
+  capability,
+  file,
+  umount,
+
+  deny /proc/* w,
+  deny /proc/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny /proc/sys/[^k]** w,
+  deny /proc/sys/kernel/{?,??,[^s][^h][^m]**} w,
+  deny /proc/sysrq-trigger rwklx,
+  deny /proc/kcore rwklx,
+  deny /proc/kmem rwklx,
+  deny /proc/mem rwklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+}
+PROFILE_EOF
+
+echo " - profile written to ${PROFILE}"
+
+# Load it now (replace if already loaded)
+if ! apparmor_parser -Kr "${PROFILE}"; then
+  echo "ERROR: apparmor_parser could not load ${PROFILE}"
+  exit 1
+fi
+if ! grep -q 'docker-default' /sys/kernel/security/apparmor/profiles; then
+  echo "ERROR: docker-default not present after load"
+  exit 1
+fi
+echo " - docker-default profile loaded ? 🟢"
+
+# Load it at every ContainerManager start, before dockerd. The profile is
+# consumed by dockerd, so unlike the FORWARD rules this must run pre-daemon.
+if ! grep -q 'docker-default.profile' "${SSS}"; then
+  INSERT="            # Added by docker update\n            [ -f ${PROFILE} ] && apparmor_parser -Kr ${PROFILE}"
+  match="^[[:space:]]*# start docker[[:space:]]*$"
+  sed -i "/${match}/i\\${INSERT}" "${SSS}"
+  if grep -q 'docker-default.profile' "${SSS}"; then
+    echo " - CM script loads profile   ? 🟢"
+  else
+    echo "ERROR: could not add profile load to ${SSS} - anchor '# start docker' not found"
+    exit 1
+  fi
+else
+  echo " - CM script loads profile   ? 🟢 (already present)"
+fi
+
+exit 0

--- a/switch_forward.sh
+++ b/switch_forward.sh
@@ -8,52 +8,63 @@ if [ "${id}" -ne 0 ]; then
 fi
 
 # Define the lines to insert
-FORWARD_ACCEPT="        iptables -P FORWARD ACCEPT\n        iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
-DOCKER_FORWARD="        iptables -I FORWARD -i docker0 -j ACCEPT\n        iptables -I FORWARD -o docker0 -j ACCEPT\n        iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
+FORWARD_ACCEPT="            # Added by docker update\n          iptables -P FORWARD ACCEPT\n          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
+DOCKER_FORWARD="            # Added by docker update\n          iptables -I FORWARD -i docker0 -j ACCEPT\n          iptables -I FORWARD -o docker0 -j ACCEPT\n          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
 
 # File to edit
 file="/var/packages/ContainerManager/scripts/start-stop-status"
 
+# Determine the current mode before removing anything
 if grep -q 'iptables -P FORWARD ACCEPT' "${file}"; then
+  mode="accept"
+elif grep -q 'iptables -I FORWARD -i docker0 -j ACCEPT' "${file}"; then
+  mode="docker0"
+else
+  echo "No IP FORWARD rules found in ${file}."
+  exit 0
+fi
 
-  # this has the FORWARD ACCEPT rule in place.
+# Remove the existing forwarding block, wherever it landed. Earlier versions inserted it before
+# 'start_docker_daemon', where the DOCKER-FORWARD chain does not yet exist. The insmod block
+# sharing the same comment is left untouched.
+sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
+sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -I FORWARD -i docker0/d}' "${file}"
+sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
+sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
+
+# Insert only after the daemon is confirmed up. dockerd creates the DOCKER-FORWARD chain, so the
+# jump rule cannot be added any earlier.
+match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+if ! grep -qE "${match}" "${file}"; then
+  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+  echo "         Forwarding configuration was NOT added -- check the file manually."
+  exit 1
+fi
+
+if [ "${mode}" = "accept" ]; then
   echo "Found FORWARD ACCEPT policy in start-stop-status script..."
   echo "Switching to docker FORWARD rules"
-  match="^[[:space:]]*iptables -P FORWARD ACCEPT"
-  # Use sed to replace the line with the DOCKER_FORWARD line
-  sed -i "/${match}/c\\${DOCKER_FORWARD}" "${file}"
-  echo "Modified FORWARD ACCEPT line with docker FORWARD rules"
+  sed -i "/${match}/i\\${DOCKER_FORWARD}" "${file}"
+  echo "Replaced FORWARD ACCEPT policy with docker FORWARD rules (post daemon start)"
   echo
   echo "To avoid a restart of docker, applying the rules now. This should automatically apply"
-  echo "  with the next docker restart"
+  echo " with the next docker restart"
   iptables -I FORWARD -i docker0 -j ACCEPT
   iptables -I FORWARD -o docker0 -j ACCEPT
   iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
-
-elif grep -q 'iptables -I FORWARD -i docker0 -j ACCEPT' "${file}"; then
-
-  # this already has the DOCKER rules applied.
+else
   echo "Found FORWARD rules for docker interface in start-stop-status script..."
   echo "Switching to FORWARD ACCEPT policy"
-  match="^[[:space:]]*iptables -I FORWARD -i docker0 -j ACCEPT"
-  # Use sed to replace docker0 lines with FORWARD ACCEPT.
-  # Handle both old (2-line) and new (3-line, includes DOCKER-FORWARD guard) docker0 blocks.
-  if grep -q 'DOCKER-FORWARD' "${file}"; then
-    sed -i "/${match}/{N;N;s/.*\n.*\n.*/${FORWARD_ACCEPT}/}" "${file}"
-  else
-    sed -i "/${match}/{N;s/.*\n.*/${FORWARD_ACCEPT}/}" "${file}"
-  fi
-  echo "Restored FORWARD ACCEPT line"
+  sed -i "/${match}/i\\${FORWARD_ACCEPT}" "${file}"
+  echo "Restored FORWARD ACCEPT policy (post daemon start)"
   echo
   echo "To avoid a restart of docker, applying the rules now. This should automatically apply"
-  echo "  with the next docker restart"
+  echo " with the next docker restart"
   # Remove the iptables rules that were previously inserted
-  iptables -D FORWARD -i docker0 -j ACCEPT
-  iptables -D FORWARD -o docker0 -j ACCEPT
+  iptables -D FORWARD -i docker0 -j ACCEPT 2>/dev/null
+  iptables -D FORWARD -o docker0 -j ACCEPT 2>/dev/null
   # Reset default policy
   iptables -P FORWARD ACCEPT
   iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
-
-else
-  echo "No IP FORWARD rules found in ${file}."
 fi

--- a/switch_forward.sh
+++ b/switch_forward.sh
@@ -24,6 +24,16 @@ else
   exit 0
 fi
 
+# Verify the insertion anchor exists before touching the file, so a missing anchor leaves
+# the file unmodified. dockerd creates the DOCKER-FORWARD chain, so the jump rule cannot be
+# added any earlier than this anchor.
+match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+if ! grep -qE "${match}" "${file}"; then
+  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+  echo "         File left unmodified -- check the file manually."
+  exit 1
+fi
+
 # Remove the existing forwarding block, wherever it landed. Earlier versions inserted it before
 # 'start_docker_daemon', where the DOCKER-FORWARD chain does not yet exist. The insmod block
 # sharing the same comment is left untouched.
@@ -32,15 +42,6 @@ sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*ip
 sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -I FORWARD -i docker0/d}' "${file}"
 sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
 sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
-
-# Insert only after the daemon is confirmed up. dockerd creates the DOCKER-FORWARD chain, so the
-# jump rule cannot be added any earlier.
-match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
-if ! grep -qE "${match}" "${file}"; then
-  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
-  echo "         Forwarding configuration was NOT added -- check the file manually."
-  exit 1
-fi
 
 if [ "${mode}" = "accept" ]; then
   echo "Found FORWARD ACCEPT policy in start-stop-status script..."

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -985,20 +985,24 @@ execute_update_script() {
     # File to edit
     file="${SYNO_DOCKER_SCRIPT}"
 
-    # Search and check conditions
-    if ! grep -q 'iptables -P FORWARD ACCEPT' "${file}"; then
-      match="^[[:space:]]*# start docker[[:space:]]*$"
-      # Use sed to append the lines before the match
+    # Remove any previously-inserted forwarding block, wherever it landed.
+    # Older versions of this script inserted it before 'start_docker_daemon',
+    # where the DOCKER-FORWARD chain does not yet exist. Only the iptables
+    # FORWARD lines (and the comment directly above them) are removed; the
+    # identically-commented insmod block is left untouched.
+    sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+    sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
+    sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
+
+    # Insert only after the daemon is confirmed up. dockerd creates the
+    # DOCKER-FORWARD chain, so the jump rule cannot be added any earlier.
+    match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+    if grep -qE "${match}" "${file}"; then
       sed -i "/${match}/i\\${SYNO_DOCKER_SCRIPT_FORWARDING}" "${file}"
-      echo "Added missing IP forwarding configuration to ${file}."
+      echo "Added IP forwarding configuration to ${file} (post daemon start)."
     else
-      echo "IP forwarding is already enabled in ${file}."
-    fi
-    # Ensure DOCKER-FORWARD jump rule is present (Docker v25+ compatibility)
-    if ! grep -q 'DOCKER-FORWARD' "${file}"; then
-      match="^[[:space:]]*iptables -P FORWARD ACCEPT"
-      sed -i "/${match}/a\\          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD" "${file}"
-      echo "Added DOCKER-FORWARD jump rule to ${file}."
+      echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+      echo "         IP forwarding configuration was NOT added — check the file manually."
     fi
   else
     echo "Skipping configuration in STAGE mode"

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -997,23 +997,25 @@ execute_update_script() {
     # File to edit
     file="${SYNO_DOCKER_SCRIPT}"
 
-    # Remove any previously-inserted forwarding block, wherever it landed. Older versions of this script (and
-    # fix_ipforward.sh / switch_forward.sh) inserted it before 'start_docker_daemon'. Only the iptables FORWARD lines
-    # (and the comment directly above them) are removed; the identically-commented insmod block added by
-    # install_iptables_modules.sh is left untouched.
-    sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
-    sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
-    sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
-    sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
-
-    # Insert only after the daemon is confirmed up.
+    # Verify the insertion anchor exists before touching the file, so a missing anchor leaves
+    # the file unmodified.
     match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
     if grep -qE "${match}" "${file}"; then
+      # Remove any previously-inserted forwarding block, wherever it landed. Older versions of this script (and
+      # fix_ipforward.sh / switch_forward.sh) inserted it before 'start_docker_daemon'. Only the iptables FORWARD lines
+      # (and the comment directly above them) are removed; the identically-commented insmod block added by
+      # install_iptables_modules.sh is left untouched.
+      sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+      sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
+      sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
+      sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
+
+      # Insert only after the daemon is confirmed up.
       sed -i "/${match}/i\\${SYNO_DOCKER_SCRIPT_FORWARDING}" "${file}"
       echo "Added IP forwarding configuration to ${file} (post daemon start)."
     else
       echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
-      echo "         IP forwarding configuration was NOT added -- check the file manually."
+      echo "         File left unmodified -- check the file manually."
     fi
   else
     echo "Skipping configuration in STAGE mode"

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -148,6 +148,7 @@ usage() {
   echo "  restore                Restore Docker and Docker Compose from backup"
   echo "  update                 Update Docker and Docker Compose to target version (creates backup first)"
   echo "  logger                 Update ONLY the logging driver to the local logger (a proactive preparation step)"
+  echo "  only_script            Update ONLY the start-stop-status IP forwarding block (no binaries, no restart)"
   echo "  validate               Validates versions available for update"
   echo
 }
@@ -973,6 +974,13 @@ execute_update_log() {
 #======================================================================================================================
 # Updates Synology's start-stop-status script for Docker to ensure IP forwarding is enabled, unless 'stage' is set to
 # true.
+#
+# The forwarding block MUST be inserted after 'start_docker_daemon' has completed. The DOCKER-FORWARD chain is created
+# by dockerd itself, so inserting the jump rule any earlier means 'iptables -C FORWARD -j DOCKER-FORWARD' fails (the
+# chain does not exist) and the fallback 'iptables -I FORWARD 1 -j DOCKER-FORWARD' fails too. dockerd then sets the
+# FORWARD policy to DROP, leaving a DROP policy with no jump - published container ports become unreachable from other
+# hosts after every clean boot, while working again after any subsequent Container Manager restart (because dockerd
+# already exists by then). That masking is what makes the bug look intermittent when it is actually deterministic.
 #======================================================================================================================
 # Globals:
 #   - stage
@@ -985,24 +993,23 @@ execute_update_script() {
     # File to edit
     file="${SYNO_DOCKER_SCRIPT}"
 
-    # Remove any previously-inserted forwarding block, wherever it landed.
-    # Older versions of this script inserted it before 'start_docker_daemon',
-    # where the DOCKER-FORWARD chain does not yet exist. Only the iptables
-    # FORWARD lines (and the comment directly above them) are removed; the
-    # identically-commented insmod block is left untouched.
+    # Remove any previously-inserted forwarding block, wherever it landed. Older versions of this script (and
+    # fix_ipforward.sh / switch_forward.sh) inserted it before 'start_docker_daemon'. Only the iptables FORWARD lines
+    # (and the comment directly above them) are removed; the identically-commented insmod block added by
+    # install_iptables_modules.sh is left untouched.
     sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+    sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
     sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
     sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
 
-    # Insert only after the daemon is confirmed up. dockerd creates the
-    # DOCKER-FORWARD chain, so the jump rule cannot be added any earlier.
+    # Insert only after the daemon is confirmed up.
     match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
     if grep -qE "${match}" "${file}"; then
       sed -i "/${match}/i\\${SYNO_DOCKER_SCRIPT_FORWARDING}" "${file}"
       echo "Added IP forwarding configuration to ${file} (post daemon start)."
     else
       echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
-      echo "         IP forwarding configuration was NOT added — check the file manually."
+      echo "         IP forwarding configuration was NOT added -- check the file manually."
     fi
   else
     echo "Skipping configuration in STAGE mode"
@@ -1107,7 +1114,7 @@ install_modules() {
   print_status "Checking for / Installing iptables modules."
   if [[ "${install_iptables_modules}" == 'true' ]]; then
   echo "   Based on this version of docker, we'll need to check for / install iptables modules..."
-  ./install_iptables_modules.sh || terminate "Could not install iptables modules. Stopping."
+  "${SCRIPT_DIR}/install_iptables_modules.sh" || terminate "Could not install iptables modules. Stopping."
   fi
 }
 

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -112,6 +112,7 @@ step=0
 total_steps=0
 install_iptables_modules='false'
 skip_iptables_modules='false'
+install_apparmor='false'
 
 
 #======================================================================================================================
@@ -534,6 +535,10 @@ define_update() {
     major="${target_docker_version%%.*}"
     if [[ "$major" -ge 28 && "${skip_iptables_modules}" = 'false' ]]; then
       install_iptables_modules='true'
+      total_steps=$((total_steps+1))
+    fi
+    if [[ "$major" -ge 29 ]]; then
+      install_apparmor='true'
       total_steps=$((total_steps+1))
     fi
     if [ "${docker_version}" = "${target_docker_version}" ] && [ "${skip_docker_update}" = 'false' ] ; then
@@ -1118,6 +1123,21 @@ install_modules() {
 }
 
 #======================================================================================================================
+# Installs a docker-default AppArmor profile for v29+ (see install_apparmor_profile.sh)
+#======================================================================================================================
+# Globals:
+#   - install_apparmor
+# Outputs:
+#   profile installed and loaded, start script modified (if necessary)
+#======================================================================================================================
+install_apparmor_profile() {
+  if [[ "${install_apparmor}" == 'true' ]]; then
+    print_status "Installing docker-default AppArmor profile."
+    bash "${SCRIPT_DIR}/install_apparmor_profile.sh" || terminate "Could not install AppArmor profile. Stopping."
+  fi
+}
+
+#======================================================================================================================
 # Removes the temp folder.
 #======================================================================================================================
 # Globals:
@@ -1293,6 +1313,7 @@ main() {
       execute_install_bin
       execute_update_log
       execute_update_script
+      install_apparmor_profile
       execute_start_syno
       execute_clean
       ;;

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -74,8 +74,7 @@ readonly SYNO_DOCKER_SCRIPT_FORWARDING="            # Added by docker update\n  
 readonly SYNO_SERVICE_STOP_TIMEOUT='10m'
 readonly SYNOPKG_BIN='/usr/syno/bin/synopkg'
 readonly SYNOSERVICECTL_BIN='/usr/syno/sbin/synoservicectl'
-RUNNING_CONTAINERS=$(docker ps -q 2>/dev/null | awk 'NF' | wc -l)
-if [ $? -ne 0 ]; then
+if ! RUNNING_CONTAINERS=$(docker ps -q 2>/dev/null | awk 'NF' | wc -l); then
   RUNNING_CONTAINERS=0
 fi
 if [ "$RUNNING_CONTAINERS" -gt 5 ]; then


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/telnetdoogie/synology-docker#contributing) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/telnetdoogie/synology-docker/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes (if applicable)?
- [x] Have you successfully run your changes locally?

---

- [x] AI was used to generate or assist with generating this PR. _Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes._ Non-maintainers may only have one AI-assisted/generated PR open at a time.

AI (Claude) assisted with root-cause analysis and drafting the patch and this PR text. All changes were manually verified on real hardware (DS718+, apollolake, DSM 7.4.1-90080): each failure was reproduced before its fix, each fix was applied and verified individually, the complete script was run once from a factory-restored stock Container Manager (24.0.2) straight to Docker 29.8.0 followed by a cold reboot with every check passing, and the two companion scripts were exercised against the live start-stop-status (no-op, repair, and mode round-trip cases) with the file diffing byte-identical to a golden copy at the end. Details in Testing below.

---

## Summary

Two independent bugs make updated engines unreliable on Synology, both rooted in
`start-stop-status` ordering. This PR fixes both:

1. **The IP forwarding block is inserted before dockerd starts, where it cannot
   work** - published container ports become unreachable from other hosts after
   every clean boot. Fixed in `syno_docker_update.sh` and in the two companion
   scripts (`fix_ipforward.sh`, `switch_forward.sh`) that carried the same
   defect independently.
2. **Docker >= 29.4.3 cannot load its AppArmor profile through DSM's ancient
   `apparmor_parser`** - containers fail to start with a segmentation fault.
   This is the failure behind the README's current "pin to 28.x" warning
   (see moby/moby#52785, filed from this repo's user base); with this PR the
   warning can likely be retired.

## Fix 1: FORWARD -> DOCKER-FORWARD ordering

`execute_update_script()` inserts the forwarding block before the
`# start docker` marker, i.e. before `start_docker_daemon` runs. The
`DOCKER-FORWARD` chain is created by dockerd itself, so at that point:

- `iptables -C FORWARD -j DOCKER-FORWARD` fails (chain missing), and
- the fallback `iptables -I FORWARD 1 -j DOCKER-FORWARD` also fails
  (cannot insert a jump to a nonexistent chain).

Neither failure is checked. dockerd then starts and sets the `FORWARD` policy
to `DROP`, overwriting the `-P FORWARD ACCEPT` set two lines earlier - leaving
a DROP policy with no jump rule.

**Symptom:** after every clean boot, containers show Up with ports published,
the nat DNAT rule is correct, `DOCKER-FORWARD` is fully populated - but nothing
in `FORWARD` ever reaches it, so published ports are unreachable from other
hosts (connections hang). Traffic from the NAS itself to the container's bridge
IP still works (locally-originated traffic goes through OUTPUT, never FORWARD),
which hides the cause. Any subsequent Container Manager restart masks the bug
(dockerd already exists, so re-running the block succeeds), making it look
intermittent when it is deterministic on every clean boot.

**Change:** the block is now inserted after `start_docker_daemon` succeeds
(anchored on `$DockerUpdaterBin postdaemonup`, which is unique in the file).
Any previously-inserted forwarding block - from older versions of this script,
`fix_ipforward.sh`, or `switch_forward.sh`, wherever it landed - is removed
first, so already-affected installs self-migrate on their next update (the old
`grep` guard skipped them forever). If the anchor is ever missing, the script
now warns loudly instead of silently not inserting. The separate
DOCKER-FORWARD insertion block (old ~L997-1001) is dropped: it anchored off
`iptables -P FORWARD ACCEPT` and inherited its wrong position, and
`SYNO_DOCKER_SCRIPT_FORWARDING` already contains both lines.

**Known limitation:** even post-daemon, the `-C || -I` jump
insertion is best-effort - dockerd reports ready (answers `docker version`)
slightly before its filter chains exist, so on some boots the jump insert still
loses that race. The `-P FORWARD ACCEPT` line is the guarantee that forwarding
works regardless; the jump (which routes traffic through Docker's per-port
filter rules) lands on any subsequent Container Manager restart. A userland
retry loop could close this fully; happy to follow up if wanted.

## Fix 2: AppArmor profile for Docker >= 29.4.3

Docker >= 29.4.3 pipes its generated `docker-default` profile to
`apparmor_parser` via stdin. DSM ships `apparmor_parser` 2.9 (2014), which
segfaults on that input. Every container start then fails with:

```
AppArmor enabled on system but the docker-default profile could not be loaded:
running '/sbin/apparmor_parser -Kr' failed with output: Warning from stdin
(line 1): apparmor_parser: cannot use or update cache, disable, or
force-complain via stdin
error: signal: segmentation fault (core dumped)
```

dockerd skips generating/loading the profile entirely when one named
`docker-default` is already loaded - so pre-loading a compatible profile
avoids the crashing code path altogether.

**Change:** new `install_apparmor_profile.sh` (sibling of
`install_iptables_modules.sh`), gated in `define_update()` on target major
version >= 29, so installs of 28.x and below are completely untouched. It:

- writes a `docker-default` profile (derived from moby's template, in syntax
  the 2.9 parser accepts: no includes, no `@{PROC}` tunables, no ptrace/signal
  rules - not mediated on these kernels anyway) to
  `${SYNO_DOCKER_DIR}/etc/docker-default.profile`, beside `dockerd.json`
- loads it immediately and verifies it appears in the kernel
- adds one guarded line to `start-stop-status` before `# start docker`
  (pre-daemon is required here - the inverse of Fix 1, since dockerd consumes
  the profile rather than creating it; AppArmor itself is kernel-built-in and
  active long before this script runs, so there is nothing to race)
- skips cleanly on systems without AppArmor enabled

The inserted line is `[ -f ... ] && apparmor_parser -Kr ...`, so a restored
backup that predates the profile file boots cleanly as a no-op. `restore`
already reverts the `start-stop-status` patch wholesale (the file is in the
backup archive); the profile file itself is left behind inert, matching how
the iptables `.ko` files are handled.

## Drive-by fixes

- `install_modules()` called `./install_iptables_modules.sh` by relative path,
  failing when the script is invoked from another directory; now
  `"${SCRIPT_DIR}/..."` for consistency with `execute_update_log()`.
  The new helper is invoked via `bash "${SCRIPT_DIR}/..."` so it does not
  depend on the executable bit.
- Documented the existing (hidden) `only_script` command in `usage()` - it is
  also the easiest in-place repair for already-affected `start-stop-status`
  files: `sudo ./syno_docker_update.sh only_script`.

## Testing

DS718+ (apollolake), DSM 7.4.1-90080, kernel 4.4.302+, containers on
user-defined bridge and macvlan networks, agent-based Portainer:

- **Fix 1:** failure reproduced on clean boot before the change (FORWARD policy
  DROP, no jump, published agent port unreachable externally; internal
  bridge-IP access fine). Manual two-command application restored connectivity
  instantly. Patched insertion verified: correct position, idempotent
  (repeated `only_script` runs produce zero diff), survives clean reboots,
  migrates a previously mis-positioned block.
- **Fix 2:** segfault reproduced on 29.8.0 after clean boot (containers
  Exited(2), error above). Profile load validated live: parser accepts it
  (exit 0), container start succeeds immediately after, with no other change.
- **Combined, from scratch:** `restore` to stock Container Manager 24.0.2
  (verified: zero patch remnants in `start-stop-status`), then a single
  `update --docker 29.8.0` run with this PR's files, then a cold reboot.
  After boot with no manual intervention: `docker-default` loaded, engine
  29.8.0, containers autostarted, published agent port reachable from another
  host, Portainer stack deploys working, no errors in the Container Manager
  UI.
- **Companion scripts, on hardware against the live `start-stop-status`:**
  `fix_ipforward.sh` run on an already-correct file is a byte-identical no-op
  (diff against a golden copy empty), and run on a deliberately re-broken file
  (block re-inserted at the old pre-daemon anchor) removes the misplaced block
  and reinserts it post daemon start. `switch_forward.sh` round-trips both
  modes: accept -> docker0 inserts the docker0 variant at the correct position
  and applies the two live rules; docker0 -> accept restores the file
  byte-identically and removes the live rules. After the full sequence
  (no-op, break, repair, switch, switch back) the file diffs clean against
  the original golden copy, and `bash -n` passes at every step.
- Log driver preflight per the README (`local` daemon default, all containers
  `local`) done before each update run.

## Notes

- `fix_ipforward.sh` and `switch_forward.sh` shared Fix 1's ordering defect
  independently (`fix_ipforward.sh` anchored on `iptablestool --insmod`, even
  earlier in the start block; `switch_forward.sh` rewrote the block's content
  in place and never repositioned it). Both are updated in this PR to use the
  same normalize-then-insert logic as `execute_update_script()`: remove any
  previously-inserted forwarding lines wherever they landed, then insert the
  chosen variant after the daemon-start guard. Both were validated on
  hardware - see Testing.
- With Fix 2 in place, the README's 29.x warning may be reducible to a note;
