### PR TITLE
[FR] fix: resolve helper scripts via SCRIPT_DIR, and guard jq array access for mountless containers

### DIFF
--- a/container_recreate.sh
+++ b/container_recreate.sh
@@ -42,7 +42,7 @@ host_env=$(printenv | awk -F= '{print $1}' | sort)
 
 debug "env variables..."
 # Extract container environment variables and filter out those present on the host - default to empty if no env vars
-env_vars=$(echo "$container_info" | jq -r '.[0].Config.Env[] // [] ' | awk -F= '{print $1}' | sort)
+env_vars=$(echo "$container_info" | jq -r '(.[0].Config.Env // [])[]' | awk -F= '{print $1}' | sort)
 filtered_env_vars=$(comm -23 <(echo "$env_vars") <(echo "$host_env"))
 
 # Add base docker command to the array
@@ -74,7 +74,7 @@ fi
 
 debug "volumes..."
 # Extract volumes and add each volume to the array individually
-volumes=$(echo "$container_info" | jq -r '.[0].Mounts[] // [] | "-v " + .Source + ":" + .Destination')
+volumes=$(echo "$container_info" | jq -r '(.[0].Mounts // [])[] | "-v " + .Source + ":" + .Destination')
 if [ -n "$volumes" ]; then
   # Add each volume as a separate entry
   while IFS= read -r volume; do

--- a/syno_docker_list_containers.sh
+++ b/syno_docker_list_containers.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+
 # Store container information in an array
 containers_info=()
 readonly NOT_COMPOSE="!---not_managed_by_compose---!"
@@ -63,7 +65,7 @@ if [ ${#docker_managed[@]} -gt 0 ]; then
   echo "If these containers already show as 'local' logger, there is no need to recreate them manually"
   echo
   for container in "${docker_managed[@]}"; do
-  docker_command=$(./container_recreate.sh $container)
+  docker_command=$("${SCRIPT_DIR}/container_recreate.sh" "$container")
   echo "----------------------------------------------------"
   echo "Container: ${container}"
   echo "----------------------------------------------------"

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -1102,7 +1102,7 @@ install_modules() {
   print_status "Checking for / Installing iptables modules."
   if [[ "${install_iptables_modules}" == 'true' ]]; then
   echo "   Based on this version of docker, we'll need to check for / install iptables modules..."
-  ./install_iptables_modules.sh || terminate "Could not install iptables modules. Stopping."
+  "${SCRIPT_DIR}/install_iptables_modules.sh" || terminate "Could not install iptables modules. Stopping."
   fi
 }
 


### PR DESCRIPTION
Fixes both problems reported in #94. Two small commits; no behaviour change outside the failure cases.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/telnetdoogie/synology-docker#contributing) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/telnetdoogie/synology-docker/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes (if applicable)?
- [x] Have you successfully run your changes locally?

---

- [x] AI was used to generate or assist with generating this PR.

---

## 1. Helper scripts resolved via `SCRIPT_DIR` rather than the CWD

`syno_docker_update.sh` already defines `SCRIPT_DIR` at line 48 and already uses it for `syno_docker_switch_logger.sh` — but `install_iptables_modules.sh` was still invoked as `./install_iptables_modules.sh`. This makes it consistent.

Why it matters: `backup_current_docker()` does `cd "${backup_dir}"`. Passing `--path` with a directory outside the clone leaves the CWD there for the rest of the run, so step 2 fails with a misleading `No such file or directory` even though the helper is present and executable — and the run aborts before anything is replaced.

That's why it isn't reproducible in normal use: without `--path`, `backup_dir` defaults to `$PWD`, the `cd` is a no-op, and the relative call resolves fine.

`syno_docker_list_containers.sh` had the same relative call to `container_recreate.sh` and no `SCRIPT_DIR` defined, so it gains one. Its `$container` argument is now quoted, since I was already touching the line.

This is deliberately narrower than restoring the CWD inside `terminate` — it fixes the success path as well as the error path, and leaves the existing `cd` behaviour alone. Happy to switch to the `terminate` approach instead if you'd prefer it.

Note this is a different axis from #84: that fixed PATH resolution for Synology *binaries* under sudo, whereas this is about locating the repo's own *scripts*.

## 2. `jq` guards so mountless containers don't error

```
jq: error (at <stdin>:225): Cannot index array with string "Destination"
```

`.[0].Mounts[] // []` applies the alternative operator to the *iteration*. When a container has no mounts the left side produces no output, so `// []` substitutes an empty **array**, and the following `.Destination` then fails. Guarding the array before iterating — `(.[0].Mounts // [])[]` — yields an empty iteration instead, which is the intent.

On my box this fired for exactly 4 of 36 running containers: the ones with no mounts that are also not compose-managed, which is the subset `syno_docker_list_containers.sh` passes to `container_recreate.sh`.

The same pattern on `.Config.Env` is corrected for consistency. It was harmless there only because the result is piped to `awk` rather than indexed.

## Testing — on real hardware

DS918+ (apollolake), DSM 7.3.2, kernel 4.4.302+, Docker 28.5.2, btrfs storage driver, 36 running containers.

**`container_recreate.sh`, before and after, against a mountless container** (`cloudflared`, 0 mounts). Token redacted:

```
=== ORIGINAL ===
jq: error (at <stdin>:225): Cannot index array with string "Destination"
docker run -d \
    --name cloudflared \
    -e "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt" \
    -it cloudflare/cloudflared:latest tunnel run --token <REDACTED>

=== PATCHED ===
docker run -d \
    --name cloudflared \
    -e "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt" \
    -it cloudflare/cloudflared:latest tunnel run --token <REDACTED>
```

Error gone, output otherwise identical.

**Regression check against a container that *does* have mounts** (`npm`, 2 mounts) — both `-v` flags still emitted, so the guard doesn't drop volumes on the normal path:

```
docker run -d \
    --name npm \
    ... (env vars omitted) ...
    -p 4430:443/tcp \
    -p 810:80/tcp \
    -p 81:81/tcp \
    -v /volume1/docker/npm/data:/data \
    -v /volume1/docker/npm/letsencrypt:/etc/letsencrypt \
    -it jc21/nginx-proxy-manager:latest
```

**`syno_docker_update.sh`:** all three scripts pass `bash -n`. The `SCRIPT_DIR` change was verified in effect on the same hardware during my own 24.0.2 → 28.5.2 upgrade — I patched the equivalent absolute path in locally to get past step 2, and the upgrade then completed successfully. I have **not** re-run a full upgrade from this branch, since the NAS is now on 28.5.2 and rolling it back to retest isn't something I want to do on a production box. If that's not sufficient, tell me what would be and I'll find a window.

No new tests: the repo has no test suite for these scripts, and I didn't want to introduce a harness uninvited as part of a bugfix. Glad to add one if you'd like it.

## AI disclosure

I used Claude (Anthropic) throughout, as an assistant rather than an author-of-record:

- **Diagnosis** — I hit both bugs during a real 24.0.2 → 28.5.2 upgrade. Claude traced the `No such file or directory` to the `cd "${backup_dir}"` at line 759 and the `--path` interaction, and identified the `// []` precedence problem as the jq root cause.
- **The patch** — Claude wrote the changes. They're five lines across three files; I read every one against the surrounding code before committing.
- **Verification — done by me, on real hardware.** I ran the before/after and regression tests above on my own DS918+ and pasted the actual output. The `bash -n` checks are real. The `SCRIPT_DIR` claim reflects an upgrade I actually performed on this machine.
- **What is not verified** is stated plainly above: no full upgrade run from this branch.

The issue report in #94 was likewise AI-assisted, and my earlier claim there that it "always fails" was wrong — you were right to question it, and running that down is what produced the `--path` finding.