### PR TITLE
[FR] Fix start-stop-status ordering for FORWARD rules; add AppArmor profile install to unbreak Docker 29.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,6 @@ If you’re comfortable with SSH and `sudo`, this is for you.
 > You can absolutely break things if you ignore instructions. Always have backups.
 > Once upgraded, The ContainerManager UI will no longer work reliably for managing containers or observing logs.
 
-> [!WARNING]\
-> **Some users are experiencing Container Manager failures after updating to Docker 29.x.**
->
-> > This is a known issue between Synology's Container Manager and the upstream Docker 29.x release. If you run into this, roll back using:
-> >
-> > ```bash
-> > sudo ./syno_docker_update.sh restore --backup [backup_name]
-> > ```
-> >
-> > Until Synology or upstream Docker resolves the compatibility issue, it is recommended to pin to the latest stable 28.x release using `--docker 28.x.x`.
-
 ### DSM Version
 
 Before using this, update to the most recent version of DSM that you can. That'll avoid many issues and will make sure the minor version of your kernel is up to date. I can't keep track of all of the older minor kernel versions for each platform, that would become unmanageable. Sometimes you'll need to download the latest DSM patch manually as it may not show as an automatic update for your model. Look for your latest DSM [here](https://www.synology.com/en-br/support/download)
@@ -185,6 +174,7 @@ PRs welcome.
 - Extensive testing by [@mrmuiz](https://github.com/mrmuiz)
 - Network‑pain endurance by [@CodeNodeNomad](https://github.com/CodeNodeNomad)
 - Kernel 5.x runc issue / resolution and additional repo contributions by [@bslatyer](https://github.com/bslatyer)
+- Awesome IP Forward rules fix and AppArmor update for v29+ by [@Salvora](https://github.com/Salvora)
 
 ## Origin
 

--- a/fix_ipforward.sh
+++ b/fix_ipforward.sh
@@ -8,33 +8,34 @@ if [ "${id}" -ne 0 ]; then
 fi
 
 # Define the lines to insert
-INSERT="  # Added by docker update\n  iptables -P FORWARD ACCEPT\n  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
+INSERT="            # Added by docker update\n          iptables -P FORWARD ACCEPT\n          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
 
 # File to edit
 file="/var/packages/ContainerManager/scripts/start-stop-status"
 
-# Search and check conditions
-if ! grep -q 'iptables -P FORWARD ACCEPT' "${file}"; then
-  match="^[[:space:]]*iptablestool --insmod"
-  # Use sed to append the lines after the match
-  sed -i "/${match}/a\\${INSERT}" "${file}"
-  echo "Added missing IP forwarding configuration to ${file}"
-  echo
-  echo "To avoid a restart of docker, adding the rule now. This should automatically apply"
-  echo "  with the next docker restart"
-  iptables -P FORWARD ACCEPT
-  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
-else
-  echo "IP forwarding is already enabled in ${file}."
+# Verify the insertion anchor exists before touching the file, so a missing anchor leaves
+# the file unmodified.
+match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+if ! grep -qE "${match}" "${file}"; then
+  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+  echo "         File left unmodified -- check the file manually."
+  exit 1
 fi
 
-# Ensure DOCKER-FORWARD jump rule is present (Docker v25+ compatibility)
-if ! grep -q 'DOCKER-FORWARD' "${file}"; then
-  match="^[[:space:]]*iptables -P FORWARD ACCEPT"
-  sed -i "/${match}/a\\  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD" "${file}"
-  echo "Added DOCKER-FORWARD jump rule to ${file}"
-  echo
-  echo "To avoid a restart of docker, adding the rule now. This should automatically apply"
-  echo "  with the next docker restart"
-  iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
-fi
+# Remove any previously-inserted forwarding block, wherever it landed. Earlier versions inserted it
+# before 'start_docker_daemon', where the DOCKER-FORWARD chain does not yet exist. The insmod block
+# sharing the same comment is left untouched.
+sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
+sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
+sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
+
+# Insert only after the daemon is confirmed up. dockerd creates the DOCKER-FORWARD chain, so the
+# jump rule cannot be added any earlier.
+sed -i "/${match}/i\\${INSERT}" "${file}"
+echo "Added IP forwarding configuration to ${file} (post daemon start)"
+echo
+echo "To avoid a restart of docker, adding the rules now. This should automatically apply"
+echo " with the next docker restart"
+iptables -P FORWARD ACCEPT
+iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD

--- a/install_apparmor_profile.sh
+++ b/install_apparmor_profile.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Installs a docker-default AppArmor profile and configures ContainerManager to
+# load it before dockerd starts.
+#
+# Docker >= 29.4.3 pipes its generated docker-default profile to apparmor_parser
+# via stdin, which segfaults DSM's apparmor_parser (2.9, 2014-era). Containers
+# then fail to start with:
+#   "AppArmor enabled on system but the docker-default profile could not be
+#    loaded: ... signal: segmentation fault"
+# dockerd skips generating/loading the profile when one named docker-default is
+# already loaded, so pre-loading a compatible profile avoids the crash entirely.
+# See https://github.com/moby/moby/issues/52785
+
+if [ -d "/var/packages/ContainerManager" ]; then
+  PKG_DIR='/var/packages/ContainerManager'
+elif [ -d "/var/packages/Docker" ]; then
+  PKG_DIR='/var/packages/Docker'
+else
+  echo "Docker (or ContainerManager) folder was not found."
+  exit 1
+fi
+
+PROFILE="${PKG_DIR}/etc/docker-default.profile"
+SSS="${PKG_DIR}/scripts/start-stop-status"
+
+# No AppArmor on this system - nothing to do
+if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" != "Y" ]; then
+  echo " - AppArmor not enabled on this system, skipping profile install."
+  exit 0
+fi
+
+# Profile derived from moby's contrib/apparmor template, in syntax accepted by
+# DSM's apparmor_parser 2.9 (no includes, no @{PROC} tunables, no ptrace/signal
+# rules - not mediated on these kernels).
+cat > "${PROFILE}" << 'PROFILE_EOF'
+profile docker-default flags=(attach_disconnected,mediate_deleted) {
+  network,
+  capability,
+  file,
+  umount,
+
+  deny /proc/* w,
+  deny /proc/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny /proc/sys/[^k]** w,
+  deny /proc/sys/kernel/{?,??,[^s][^h][^m]**} w,
+  deny /proc/sysrq-trigger rwklx,
+  deny /proc/kcore rwklx,
+  deny /proc/kmem rwklx,
+  deny /proc/mem rwklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+}
+PROFILE_EOF
+
+echo " - profile written to ${PROFILE}"
+
+# Load it now (replace if already loaded)
+if ! /sbin/apparmor_parser -Kr "${PROFILE}"; then
+  echo "ERROR: /sbin/apparmor_parser could not load ${PROFILE}"
+  exit 1
+fi
+if ! grep -q 'docker-default' /sys/kernel/security/apparmor/profiles; then
+  echo "ERROR: docker-default not present after load"
+  exit 1
+fi
+echo " - docker-default profile loaded ? 🟢"
+
+# Load it at every ContainerManager start, before dockerd. The profile is
+# consumed by dockerd, so unlike the FORWARD rules this must run pre-daemon.
+if ! grep -q 'docker-default.profile' "${SSS}"; then
+  INSERT="            # Added by docker update\n            [ -f \"${PROFILE}\" ] && /sbin/apparmor_parser -Kr \"${PROFILE}\""
+  match="^[[:space:]]*# start docker[[:space:]]*$"
+  sed -i "/${match}/i\\${INSERT}" "${SSS}"
+  if grep -q 'docker-default.profile' "${SSS}"; then
+    echo " - CM script loads profile   ? 🟢"
+  else
+    echo "ERROR: could not add profile load to ${SSS} - anchor '# start docker' not found"
+    exit 1
+  fi
+else
+  echo " - CM script loads profile   ? 🟢 (already present)"
+fi
+
+exit 0

--- a/switch_forward.sh
+++ b/switch_forward.sh
@@ -8,52 +8,64 @@ if [ "${id}" -ne 0 ]; then
 fi
 
 # Define the lines to insert
-FORWARD_ACCEPT="        iptables -P FORWARD ACCEPT\n        iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
-DOCKER_FORWARD="        iptables -I FORWARD -i docker0 -j ACCEPT\n        iptables -I FORWARD -o docker0 -j ACCEPT\n        iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
+FORWARD_ACCEPT="            # Added by docker update\n          iptables -P FORWARD ACCEPT\n          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
+DOCKER_FORWARD="            # Added by docker update\n          iptables -I FORWARD -i docker0 -j ACCEPT\n          iptables -I FORWARD -o docker0 -j ACCEPT\n          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD"
 
 # File to edit
 file="/var/packages/ContainerManager/scripts/start-stop-status"
 
+# Determine the current mode before removing anything
 if grep -q 'iptables -P FORWARD ACCEPT' "${file}"; then
+  mode="accept"
+elif grep -q 'iptables -I FORWARD -i docker0 -j ACCEPT' "${file}"; then
+  mode="docker0"
+else
+  echo "No IP FORWARD rules found in ${file}."
+  exit 0
+fi
 
-  # this has the FORWARD ACCEPT rule in place.
+# Verify the insertion anchor exists before touching the file, so a missing anchor leaves
+# the file unmodified. dockerd creates the DOCKER-FORWARD chain, so the jump rule cannot be
+# added any earlier than this anchor.
+match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+if ! grep -qE "${match}" "${file}"; then
+  echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+  echo "         File left unmodified -- check the file manually."
+  exit 1
+fi
+
+# Remove the existing forwarding block, wherever it landed. Earlier versions inserted it before
+# 'start_docker_daemon', where the DOCKER-FORWARD chain does not yet exist. The insmod block
+# sharing the same comment is left untouched.
+sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
+sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -I FORWARD -i docker0/d}' "${file}"
+sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
+sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
+
+if [ "${mode}" = "accept" ]; then
   echo "Found FORWARD ACCEPT policy in start-stop-status script..."
   echo "Switching to docker FORWARD rules"
-  match="^[[:space:]]*iptables -P FORWARD ACCEPT"
-  # Use sed to replace the line with the DOCKER_FORWARD line
-  sed -i "/${match}/c\\${DOCKER_FORWARD}" "${file}"
-  echo "Modified FORWARD ACCEPT line with docker FORWARD rules"
+  sed -i "/${match}/i\\${DOCKER_FORWARD}" "${file}"
+  echo "Replaced FORWARD ACCEPT policy with docker FORWARD rules (post daemon start)"
   echo
   echo "To avoid a restart of docker, applying the rules now. This should automatically apply"
-  echo "  with the next docker restart"
+  echo " with the next docker restart"
   iptables -I FORWARD -i docker0 -j ACCEPT
   iptables -I FORWARD -o docker0 -j ACCEPT
   iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
-
-elif grep -q 'iptables -I FORWARD -i docker0 -j ACCEPT' "${file}"; then
-
-  # this already has the DOCKER rules applied.
+else
   echo "Found FORWARD rules for docker interface in start-stop-status script..."
   echo "Switching to FORWARD ACCEPT policy"
-  match="^[[:space:]]*iptables -I FORWARD -i docker0 -j ACCEPT"
-  # Use sed to replace docker0 lines with FORWARD ACCEPT.
-  # Handle both old (2-line) and new (3-line, includes DOCKER-FORWARD guard) docker0 blocks.
-  if grep -q 'DOCKER-FORWARD' "${file}"; then
-    sed -i "/${match}/{N;N;s/.*\n.*\n.*/${FORWARD_ACCEPT}/}" "${file}"
-  else
-    sed -i "/${match}/{N;s/.*\n.*/${FORWARD_ACCEPT}/}" "${file}"
-  fi
-  echo "Restored FORWARD ACCEPT line"
+  sed -i "/${match}/i\\${FORWARD_ACCEPT}" "${file}"
+  echo "Restored FORWARD ACCEPT policy (post daemon start)"
   echo
   echo "To avoid a restart of docker, applying the rules now. This should automatically apply"
-  echo "  with the next docker restart"
+  echo " with the next docker restart"
   # Remove the iptables rules that were previously inserted
-  iptables -D FORWARD -i docker0 -j ACCEPT
-  iptables -D FORWARD -o docker0 -j ACCEPT
+  iptables -D FORWARD -i docker0 -j ACCEPT 2>/dev/null
+  iptables -D FORWARD -o docker0 -j ACCEPT 2>/dev/null
   # Reset default policy
   iptables -P FORWARD ACCEPT
   iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD
-
-else
-  echo "No IP FORWARD rules found in ${file}."
 fi

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -112,6 +112,7 @@ step=0
 total_steps=0
 install_iptables_modules='false'
 skip_iptables_modules='false'
+install_apparmor='false'
 
 
 #======================================================================================================================
@@ -147,6 +148,7 @@ usage() {
   echo "  restore                Restore Docker and Docker Compose from backup"
   echo "  update                 Update Docker and Docker Compose to target version (creates backup first)"
   echo "  logger                 Update ONLY the logging driver to the local logger (a proactive preparation step)"
+  echo "  only_script            Update ONLY the start-stop-status IP forwarding block (no binaries, no restart)"
   echo "  validate               Validates versions available for update"
   echo
 }
@@ -533,6 +535,10 @@ define_update() {
     major="${target_docker_version%%.*}"
     if [[ "$major" -ge 28 && "${skip_iptables_modules}" = 'false' ]]; then
       install_iptables_modules='true'
+      total_steps=$((total_steps+1))
+    fi
+    if [[ "$major" -ge 29 ]]; then
+      install_apparmor='true'
       total_steps=$((total_steps+1))
     fi
     if [ "${docker_version}" = "${target_docker_version}" ] && [ "${skip_docker_update}" = 'false' ] ; then
@@ -972,6 +978,13 @@ execute_update_log() {
 #======================================================================================================================
 # Updates Synology's start-stop-status script for Docker to ensure IP forwarding is enabled, unless 'stage' is set to
 # true.
+#
+# The forwarding block MUST be inserted after 'start_docker_daemon' has completed. The DOCKER-FORWARD chain is created
+# by dockerd itself, so inserting the jump rule any earlier means 'iptables -C FORWARD -j DOCKER-FORWARD' fails (the
+# chain does not exist) and the fallback 'iptables -I FORWARD 1 -j DOCKER-FORWARD' fails too. dockerd then sets the
+# FORWARD policy to DROP, leaving a DROP policy with no jump - published container ports become unreachable from other
+# hosts after every clean boot, while working again after any subsequent Container Manager restart (because dockerd
+# already exists by then). That masking is what makes the bug look intermittent when it is actually deterministic.
 #======================================================================================================================
 # Globals:
 #   - stage
@@ -984,20 +997,25 @@ execute_update_script() {
     # File to edit
     file="${SYNO_DOCKER_SCRIPT}"
 
-    # Search and check conditions
-    if ! grep -q 'iptables -P FORWARD ACCEPT' "${file}"; then
-      match="^[[:space:]]*# start docker[[:space:]]*$"
-      # Use sed to append the lines before the match
+    # Verify the insertion anchor exists before touching the file, so a missing anchor leaves
+    # the file unmodified.
+    match="^[[:space:]]*[$]DockerUpdaterBin postdaemonup[[:space:]]*$"
+    if grep -qE "${match}" "${file}"; then
+      # Remove any previously-inserted forwarding block, wherever it landed. Older versions of this script (and
+      # fix_ipforward.sh / switch_forward.sh) inserted it before 'start_docker_daemon'. Only the iptables FORWARD lines
+      # (and the comment directly above them) are removed; the identically-commented insmod block added by
+      # install_iptables_modules.sh is left untouched.
+      sed -i '/^[[:space:]]*iptables -C FORWARD -j DOCKER-FORWARD/d' "${file}"
+      sed -i '/^[[:space:]]*iptables -[ID] FORWARD -[io] docker0 -j ACCEPT[[:space:]]*$/d' "${file}"
+      sed -i '/^[[:space:]]*# Added by docker update[[:space:]]*$/{N;/\n[[:space:]]*iptables -P FORWARD ACCEPT/d}' "${file}"
+      sed -i '/^[[:space:]]*iptables -P FORWARD ACCEPT[[:space:]]*$/d' "${file}"
+
+      # Insert only after the daemon is confirmed up.
       sed -i "/${match}/i\\${SYNO_DOCKER_SCRIPT_FORWARDING}" "${file}"
-      echo "Added missing IP forwarding configuration to ${file}."
+      echo "Added IP forwarding configuration to ${file} (post daemon start)."
     else
-      echo "IP forwarding is already enabled in ${file}."
-    fi
-    # Ensure DOCKER-FORWARD jump rule is present (Docker v25+ compatibility)
-    if ! grep -q 'DOCKER-FORWARD' "${file}"; then
-      match="^[[:space:]]*iptables -P FORWARD ACCEPT"
-      sed -i "/${match}/a\\          iptables -C FORWARD -j DOCKER-FORWARD 2>/dev/null || iptables -I FORWARD 1 -j DOCKER-FORWARD" "${file}"
-      echo "Added DOCKER-FORWARD jump rule to ${file}."
+      echo "WARNING: anchor '\$DockerUpdaterBin postdaemonup' not found in ${file}."
+      echo "         File left unmodified -- check the file manually."
     fi
   else
     echo "Skipping configuration in STAGE mode"
@@ -1103,6 +1121,21 @@ install_modules() {
   if [[ "${install_iptables_modules}" == 'true' ]]; then
   echo "   Based on this version of docker, we'll need to check for / install iptables modules..."
   "${SCRIPT_DIR}/install_iptables_modules.sh" || terminate "Could not install iptables modules. Stopping."
+  fi
+}
+
+#======================================================================================================================
+# Installs a docker-default AppArmor profile for v29+ (see install_apparmor_profile.sh)
+#======================================================================================================================
+# Globals:
+#   - install_apparmor
+# Outputs:
+#   profile installed and loaded, start script modified (if necessary)
+#======================================================================================================================
+install_apparmor_profile() {
+  if [[ "${install_apparmor}" == 'true' ]]; then
+    print_status "Installing docker-default AppArmor profile."
+    bash "${SCRIPT_DIR}/install_apparmor_profile.sh" || terminate "Could not install AppArmor profile. Stopping."
   fi
 }
 
@@ -1282,6 +1315,7 @@ main() {
       execute_install_bin
       execute_update_log
       execute_update_script
+      install_apparmor_profile
       execute_start_syno
       execute_clean
       ;;


### PR DESCRIPTION
Continuation of #95 from @Salvora

* Refactor IP forwarding handling in syno_docker_update.sh

Fix: FORWARD → DOCKER-FORWARD jump inserted before dockerd starts

On DSM 7.x with Docker 28.x, execute_update_script() inserts the forwarding block before the # start docker marker in start-stop-status, i.e. before start_docker_daemon runs. The DOCKER-FORWARD chain is created by dockerd, so at that point it doesn't exist: iptables -C FORWARD -j DOCKER-FORWARD fails, and the fallback iptables -I FORWARD 1 -j DOCKER-FORWARD also fails (cannot jump to a nonexistent chain). Neither is checked. dockerd then starts and sets the FORWARD policy to DROP, overwriting the -P FORWARD ACCEPT set moments earlier.

Result after a cold boot: FORWARD policy DROP with no rules, while DOCKER-FORWARD is fully and correctly populated but never reached. Published container ports are unreachable from other hosts. Traffic from the NAS itself to the container's bridge IP still works (it goes via OUTPUT, never FORWARD), which makes the container look healthy and hides the cause.

The bug is masked by any subsequent Container Manager restart: dockerd already exists at that point, so the re-run of the block succeeds. This makes it look intermittent when it's actually deterministic on every clean boot.

Fix: move the insertion to after start_docker_daemon succeeds (anchored on $DockerUpdaterBin postdaemonup), and normalize any existing misplaced block so already-affected installs are migrated rather than skipped by the previous grep guard.

Tested on: DS718+, DSM 7.4.1-90080, Docker 28.5.2, containers on user-defined bridge networks. Verified failing before the change and surviving a full NAS reboot after it.

* Update IP forwarding configuration and script paths

* Refactor RUNNING_CONTAINERS assignment for error handling

* Add AppArmor profile install for Docker 29.x; invoke helpers via SCRIPT_DIR

Docker >= 29.4.3 pipes its generated docker-default profile to apparmor_parser via stdin, which segfaults DSM's 2014-era parser and breaks all container starts. Pre-loading a compatible profile makes dockerd skip its own load. Gated on target major >= 29; installs of 28.x and below are untouched. See moby/moby#52785.

* Add install_apparmor_profile.sh helper

* Fix fix_ipforward.sh: insert forwarding block post daemon start

Refactor IP forwarding script to clean up previous rules and insert new ones after daemon start.

* Fix switch_forward.sh: reposition forwarding block when switching modes

Updated iptables rules for Docker forwarding configuration in switch_forward.sh to ensure proper handling of FORWARD policies after the Docker daemon starts.

* anchor verified before any deletion; missing anchor now exits/warns

* anchor verified before any deletion; missing anchor now exits/warns

Added verification for insertion anchor before modifying the file to ensure it remains unmodified if the anchor is missing.

* anchor verified before any deletion; missing anchor now exits/warns

* Fix path to apparmor_parser in script

the line inserted into start-stop-status (and the helper's own invocations) now use the absolute /sbin/apparmor_parser, and the profile path is quoted

-----

This PR is a draft PR to continue the merge to main from @Salvora's PR #95, awaiting positive results from user testing.
