### PR TITLE
[FR] fix: Docker 29 Segmentation Faults

### DIFF
--- a/install_apparmor_profile.sh
+++ b/install_apparmor_profile.sh
@@ -1,15 +1,42 @@
 #!/bin/bash
-# Installs a docker-default AppArmor profile and configures ContainerManager to
-# load it before dockerd starts.
+# Installs an apparmor_parser wrapper and docker-default profile for Docker >= 29.
 #
 # Docker >= 29.4.3 pipes its generated docker-default profile to apparmor_parser
-# via stdin, which segfaults DSM's apparmor_parser (2.9, 2014-era). Containers
-# then fail to start with:
+# via stdin. Synology DSM's apparmor_parser (version 2.9, 2014-era) segfaults
+# when reading from stdin:
 #   "AppArmor enabled on system but the docker-default profile could not be
-#    loaded: ... signal: segmentation fault"
-# dockerd skips generating/loading the profile when one named docker-default is
-# already loaded, so pre-loading a compatible profile avoids the crash entirely.
+#    loaded: running '/sbin/apparmor_parser -Kr' failed with output: ...
+#    error: signal: segmentation fault (core dumped)"
+#
+# In upstream Moby (daemon/daemon.go), dockerd unconditionally pipes its
+# profile to apparmor_parser at startup regardless of whether docker-default
+# was pre-loaded. Furthermore, on DSM 7 systemd manages dockerd directly
+# (pkg-ContainerManager-dockerd.service), completely bypassing start-stop-status
+# on boot and restarts.
+#
+# To permanently and reliably resolve this:
+# 1. Install a transparent wrapper for /usr/sbin/apparmor_parser (saving the
+#    original binary as .real). If invoked with stdin (no file arguments), the
+#    wrapper buffers stdin to a temporary file and invokes the real parser with
+#    that file, bypassing the stdin segfault bug.
+# 2. Write and pre-load a compatible docker-default profile.
+# 3. Add the pre-load hook to start-stop-status for DSM 6 compatibility.
+#
 # See https://github.com/moby/moby/issues/52785
+
+PARSER="/usr/sbin/apparmor_parser"
+if [ ! -e "$PARSER" ] && [ -e "/sbin/apparmor_parser" ]; then
+  PARSER="/sbin/apparmor_parser"
+fi
+
+if [ -L "$PARSER" ]; then
+  REAL_PATH=$(readlink -f "$PARSER" 2>/dev/null || readlink "$PARSER")
+  if [ -n "$REAL_PATH" ] && [ -e "$REAL_PATH" ]; then
+    PARSER="$REAL_PATH"
+  fi
+fi
+
+REAL_PARSER="${PARSER}.real"
 
 if [ -d "/var/packages/ContainerManager" ]; then
   PKG_DIR='/var/packages/ContainerManager'
@@ -23,12 +50,92 @@ fi
 PROFILE="${PKG_DIR}/etc/docker-default.profile"
 SSS="${PKG_DIR}/scripts/start-stop-status"
 
+# Handle restoration if called with --restore
+if [ "$1" = "--restore" ]; then
+  if [ -f "${REAL_PARSER}" ]; then
+    mv -f "${REAL_PARSER}" "${PARSER}"
+    echo " - restored original apparmor_parser binary"
+  fi
+  if [ -f "${PROFILE}" ]; then
+    rm -f "${PROFILE}"
+    echo " - removed ${PROFILE}"
+  fi
+  if [ -f "${SSS}" ]; then
+    sed -i '/docker-default\.profile/d' "${SSS}"
+    echo " - removed profile loading from start-stop-status"
+  fi
+  exit 0
+fi
+
 # No AppArmor on this system - nothing to do
 if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" != "Y" ]; then
   echo " - AppArmor not enabled on this system, skipping profile install."
   exit 0
 fi
 
+# 1. Install apparmor_parser wrapper
+if [ -e "${PARSER}" ]; then
+  if head -n 1 "${PARSER}" | grep -q '^#!'; then
+    # Already a wrapper script
+    if [ ! -f "${REAL_PARSER}" ]; then
+      echo "ERROR: ${PARSER} is a script, but ${REAL_PARSER} does not exist."
+      exit 1
+    fi
+    echo " - apparmor_parser wrapper already installed ? 🟢"
+  else
+    # Original ELF binary
+    mv -f "${PARSER}" "${REAL_PARSER}" || {
+      echo "ERROR: Could not back up ${PARSER} to ${REAL_PARSER}"
+      exit 1
+    }
+    echo " - backed up original apparmor_parser to ${REAL_PARSER}"
+  fi
+
+  cat > "${PARSER}" << 'WRAPPER_EOF'
+#!/bin/sh
+# Synology DSM apparmor_parser wrapper to fix stdin segfault in version 2.9 (moby/moby#52785)
+REAL_PARSER="/usr/sbin/apparmor_parser.real"
+if [ ! -x "$REAL_PARSER" ]; then
+  REAL_PARSER="/sbin/apparmor_parser.real"
+fi
+
+has_file=false
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help|-V|--version)
+      exec "$REAL_PARSER" "$@"
+      ;;
+  esac
+  if [ -f "$arg" ]; then
+    has_file=true
+    break
+  fi
+done
+
+if [ "$has_file" = true ]; then
+  exec "$REAL_PARSER" "$@"
+fi
+
+# No file specified in arguments -> reading from stdin
+TMP_FILE=$(mktemp /tmp/apparmor_profile.XXXXXX)
+if [ $? -ne 0 ] || [ -z "$TMP_FILE" ]; then
+  exec "$REAL_PARSER" "$@"
+fi
+
+trap 'rm -f "$TMP_FILE"' EXIT HUP INT TERM
+
+cat > "$TMP_FILE"
+"$REAL_PARSER" "$@" "$TMP_FILE"
+exit $?
+WRAPPER_EOF
+
+  chmod 755 "${PARSER}"
+  echo " - apparmor_parser stdin wrapper installed ? 🟢"
+else
+  echo "WARNING: apparmor_parser binary not found at ${PARSER}"
+fi
+
+# 2. Write compatible docker-default profile
 # Profile derived from moby's contrib/apparmor template, in syntax accepted by
 # DSM's apparmor_parser 2.9 (no includes, no @{PROC} tunables, no ptrace/signal
 # rules - not mediated on these kernels).
@@ -63,8 +170,8 @@ PROFILE_EOF
 echo " - profile written to ${PROFILE}"
 
 # Load it now (replace if already loaded)
-if ! /sbin/apparmor_parser -Kr "${PROFILE}"; then
-  echo "ERROR: /sbin/apparmor_parser could not load ${PROFILE}"
+if ! "${PARSER}" -Kr "${PROFILE}"; then
+  echo "ERROR: ${PARSER} could not load ${PROFILE}"
   exit 1
 fi
 if ! grep -q 'docker-default' /sys/kernel/security/apparmor/profiles; then
@@ -73,10 +180,9 @@ if ! grep -q 'docker-default' /sys/kernel/security/apparmor/profiles; then
 fi
 echo " - docker-default profile loaded ? 🟢"
 
-# Load it at every ContainerManager start, before dockerd. The profile is
-# consumed by dockerd, so unlike the FORWARD rules this must run pre-daemon.
+# 3. Load it at every ContainerManager start, before dockerd (DSM 6 / package starts).
 if ! grep -q 'docker-default.profile' "${SSS}"; then
-  INSERT="            # Added by docker update\n            [ -f \"${PROFILE}\" ] && /sbin/apparmor_parser -Kr \"${PROFILE}\""
+  INSERT="            # Added by docker update\n            [ -f \"${PROFILE}\" ] && ${PARSER} -Kr \"${PROFILE}\""
   match="^[[:space:]]*# start docker[[:space:]]*$"
   sed -i "/${match}/i\\${INSERT}" "${SSS}"
   if grep -q 'docker-default.profile' "${SSS}"; then

--- a/syno_docker_update.sh
+++ b/syno_docker_update.sh
@@ -1054,6 +1054,9 @@ execute_restore_script() {
   print_status "Restoring start-stop-status script"
   if [ "${stage}" = 'false' ] ; then
     cp "${temp_dir}"/start-stop-status "${SYNO_DOCKER_SCRIPT}"
+    if [ -f "${SCRIPT_DIR}/install_apparmor_profile.sh" ]; then
+      bash "${SCRIPT_DIR}/install_apparmor_profile.sh" --restore
+    fi
   else
     echo "Skipping restoring in STAGE mode or TARGET mode"
   fi
@@ -1125,16 +1128,16 @@ install_modules() {
 }
 
 #======================================================================================================================
-# Installs a docker-default AppArmor profile for v29+ (see install_apparmor_profile.sh)
+# Installs apparmor_parser wrapper and docker-default AppArmor profile for v29+ (see install_apparmor_profile.sh)
 #======================================================================================================================
 # Globals:
 #   - install_apparmor
 # Outputs:
-#   profile installed and loaded, start script modified (if necessary)
+#   wrapper installed, profile installed and loaded, start script modified (if necessary)
 #======================================================================================================================
 install_apparmor_profile() {
   if [[ "${install_apparmor}" == 'true' ]]; then
-    print_status "Installing docker-default AppArmor profile."
+    print_status "Installing AppArmor parser wrapper and docker-default profile."
     bash "${SCRIPT_DIR}/install_apparmor_profile.sh" || terminate "Could not install AppArmor profile. Stopping."
   fi
 }


### PR DESCRIPTION
> [!NOTE]
> **Transparency / Maintainer Context:**
> *Full disclosure: I worked with an AI assistant to investigate, test, and draft this fix, as I don't have deep bash or low-level systems programming experience myself.*
> 
> *However, this is **not untested code**: I ran into the stdin segfault on my own Synology NAS (DSM 7.4.1) after upgrading to Docker 29.8.0 with the latest release (which merged #95 via #97). We diagnosed why #95 still crashed on boot and container starts, implemented and verified this exact wrapper live on the NAS, and confirmed container deployments and service restarts are now completely stable. I opened this as a draft/reference implementation in case you'd like to refine the approach or merge it.*

### Summary

This PR resolves the persistent `error: signal: segmentation fault (core dumped)` failure encountered when starting or creating containers on Docker 29.4.3+ on Synology DSM ([moby/moby#52785](https://github.com/moby/moby/issues/52785)), addressing two structural flaws in #95 / #97.

---

### Background & Root Cause Analysis

In PR #95 (commit `c083412`), the strategy was to pre-load a static `docker-default.profile` in `start-stop-status` under the assumption that `dockerd` would skip loading its own profile if a profile named `docker-default` was already present in the kernel.

In practice, Docker 29+ continued to fail with:
```text
AppArmor enabled on system but the docker-default profile could not be loaded: running '/sbin/apparmor_parser -Kr' failed with output: Warning from stdin (line 1): apparmor_parser: cannot use or update cache, disable, or force-complain via stdin

error: signal: segmentation fault (core dumped)
```

There are two primary reasons why #95 did not prevent this:

1. **Unconditional stdin pipe in Moby (`daemon/daemon.go:1003`)**:
   In upstream Moby, `dockerd` calls `d.installDefaultAppArmorProfile()` during initialization and container setup, which unconditionally pipes its generated profile template into `/sbin/apparmor_parser -Kr` via standard input (`stdin`), regardless of whether `docker-default` already exists in `/sys/kernel/security/apparmor/profiles`.

2. **DSM 7 `systemd` bypass**:
   On DSM 7, Container Manager is supervised directly by `systemd` (`pkg-ContainerManager-dockerd.service` calls `dockerd` directly). On system cold boots and service crash-restarts, `start-stop-status` is completely bypassed. Because AppArmor kernel profiles only exist in RAM and are wiped across reboots, `dockerd` boots into the crashing stdin code path.

3. **The `apparmor_parser` 2.9 stdin bug**:
   Synology DSM ships with AppArmor parser version 2.9.0 (2014) linked against Synology's libc. The parser has a memory fault / segfault (SIGSEGV, exit 139) specifically when reading profile definitions from `stdin`.
   However, when passed an identical profile as a file path argument (e.g. `apparmor_parser -Kr /path/to/profile`), it reads from the filesystem instead of stdin, parses Moby's template rules without crashing, and returns exit code `0`.

---

### Solution

1. **Transparent `apparmor_parser` Wrapper**:
   - `install_apparmor_profile.sh` now backs up `/usr/sbin/apparmor_parser` to `/usr/sbin/apparmor_parser.real` (resolving `/sbin` symlinks on DSM 7).
   - It replaces `apparmor_parser` with a lightweight, zero-overhead shell wrapper:
     - If called with flags like `--version` or `--help`, or with any positional file argument (such as during normal DSM boot when Synology loads `/etc/apparmor.d/*`), it invokes `exec "$REAL_PARSER" "$@"` directly.
     - If called with no file arguments (reading from `stdin`, as `dockerd` does), it buffers `stdin` to a temporary file via `mktemp /tmp/apparmor_profile.XXXXXX`, runs `"$REAL_PARSER" "$@" "$TMP_FILE"`, and cleans up the temp file via an `EXIT`/`TERM` trap.
2. **Profile & Start-Stop-Status Fallback**:
   - Retains the static `docker-default.profile` generation and pre-daemon load for DSM 6 compatibility.
3. **Restore Support**:
   - Added `--restore` flag to `install_apparmor_profile.sh` which restores `/usr/sbin/apparmor_parser.real` back to `apparmor_parser`, cleans up the static profile, and strips the entry from `start-stop-status`.
   - Wired `--restore` into `execute_restore_script` in `syno_docker_update.sh`.

---

### Verification

- Tested on DSM 7.4.1 (`kernel 4.4.302+`) running Docker Engine `29.8.0` (API v1.56) on x86_64.
- Verified piping profiles via stdin to `/usr/sbin/apparmor_parser -Kr` succeeds with exit `0` and loads the profile into `/sys/kernel/security/apparmor/profiles`.
- Verified container creation and execution (`docker run --rm alpine echo 'test'`) succeeds cleanly without segmentation faults.
- Verified systemd restarts (`systemctl restart pkg-ContainerManager-dockerd`) and cold boots come up cleanly without manual intervention.